### PR TITLE
Del 202 move ews scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@
 *.dll
 *.so
 *.dylib
-delorean
+/delorean
 
 # Test binary, built with `go test -c`
 *.test

--- a/scripts/delorean/csv_helper
+++ b/scripts/delorean/csv_helper
@@ -3,7 +3,6 @@
 set -e
 
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-MANIFESTS_DIR=${WORK_DIR}/../../manifests
 MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
 
 get_current_csv() {

--- a/scripts/delorean/csv_helper
+++ b/scripts/delorean/csv_helper
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MANIFESTS_DIR=${WORK_DIR}/../../manifests
+MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
+
+get_current_csv() {
+    echo "$(yq r ${MANIFESTS_DIR}/integreatly-${1}/${1}.package.yaml channels[0].currentCSV)"
+}
+
+get_current_csv_file() {
+    echo "$(grep -lR "name: $(get_current_csv $1)" ${MANIFESTS_DIR}/integreatly-$1)"
+}

--- a/scripts/delorean/mirror-images.sh
+++ b/scripts/delorean/mirror-images.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script mirrors all image mappings found in any image_mirror_mapping files
+# inside each product's manifest folder.
+# Authentication is required for any repository referenced in a mapping from the running machine.
+#
+# Example:
+# $ scripts/mirror-images.sh
+#
+
+set -e
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MANIFESTS_DIR=${WORK_DIR}/../../manifests
+ARGS=
+# ARGS is a fix for running it locally on mac. It is defaulted to empty for other OSs.
+if [[ "$OSTYPE" == "darwin"* ]]; then
+    ARGS=--filter-by-os=.*
+fi
+
+mirror_images() {
+    set -o errexit
+    failures=0
+    files=$(find ${MANIFESTS_DIR} -name "image_mirror_mapping")
+    for mapping in $files; do
+        echo "Running: oc image mirror -f=$mapping --skip-multiple-scopes $ARGS"
+        if ! oc image mirror -f="$mapping" --skip-multiple-scopes $ARGS; then
+            echo "ERROR: Failed to mirror images from $mapping"
+            failures=$((failures+1))
+        fi
+    done
+    exit $failures
+}
+
+mirror_images

--- a/scripts/delorean/mirror-images.sh
+++ b/scripts/delorean/mirror-images.sh
@@ -11,7 +11,6 @@
 set -e
 
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-MANIFESTS_DIR=${WORK_DIR}/../../manifests
 ARGS=
 # ARGS is a fix for running it locally on mac. It is defaulted to empty for other OSs.
 if [[ "$OSTYPE" == "darwin"* ]]; then
@@ -32,4 +31,9 @@ mirror_images() {
     exit $failures
 }
 
-mirror_images
+if [ -z "${MANIFESTS_DIR}" ]; then
+    echo "MANIFEST_DIR is not set!!"
+    exit 1
+else
+    mirror_images
+fi

--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+# This script locates the current cluster service version file (csv) for a given product and replaces all occurrences of internal image registries with a deloeran version and generates an image_mirror_mapping file.
+#
+# Example: Running the script and checking the changes produced
+#
+#$ ./scripts/process-csv-images 3scale
+#$ grep delorean manifests/integreatly-3scale/3scale-0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml
+#    image: quay.io/integreatly/delorean/3scale-amp2-apicast-gateway-rhel8_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-backend-rhel7_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-system-rhel7_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-zync-rhel7_3scale2.8
+#    image: quay.io/integreatly/delorean/3scale-amp2-memcached-rhel7_3scale2.8
+#$ cat manifests/integreatly-3scale/image_mirror_mapping
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-apicast-gateway-rhel8:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-apicast-gateway-rhel8_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-backend-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-backend-rhel7_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-system-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-system-rhel7_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-zync-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-zync-rhel7_3scale2.8
+#registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-memcached-rhel7:3scale2.8 quay.io/integreatly/delorean/3scale-amp2-memcached-rhel7_3scale2.8
+
+set -e
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+
+source $WORK_DIR/csv_helper
+
+RH_REGISTRY_PROD=registry.redhat.io
+RH_REGISTRY_STAGE=registry.stage.redhat.io
+RH_REGISTRY_OSBS=registry-proxy.engineering.redhat.com/rh-osbs
+DELOREAN_REGISTRY=quay.io/integreatly/delorean
+
+collect_csv_images() {
+    csv_images=(`grep -o ''${RH_REGISTRY_PROD}'.*\|'${RH_REGISTRY_STAGE}'.*' $1 | sed 's/"//' || true`)
+}
+
+process_csv_images() {
+    echo "Generate Image Mirror Mapping for $2"
+    image_mirror_mapping=${MANIFESTS_DIR}/integreatly-${2}/image_mirror_mapping
+
+    for image in "${csv_images[@]}"
+    do
+        echo "Processing image $image"
+        # The below logic is specific to the amq-broker image
+        if [[ $image == *"amq-broker"* ]]; then
+            image_version="$(echo $image | cut -f2 -d":")"
+            group_image_version="$(echo ${image_version} | tr -d '.')"
+            major_version="$(echo $image_version | cut -f1 -d".")"
+            osbs_image_path="amq-broker-$major_version-amq-broker-$group_image_version-openshift:${image_version}"
+        else
+            image_path="$(echo $image | grep / | cut -d/ -f2-)"
+            osbs_image_path="$(echo $image_path | sed 's/\//-/')"
+        fi
+        delorean_image_tag="$(echo $osbs_image_path | sed 's/:/_/' | sed 's/@sha256.*$/_latest/')"
+
+        osbs_image="${RH_REGISTRY_OSBS}/${osbs_image_path}"
+        delorean_image="${DELOREAN_REGISTRY}:${delorean_image_tag}"
+
+        echo "CSV Image: ${image}"
+        echo "OSBS Image: ${osbs_image}"
+        echo "Delorean Image: ${delorean_image}"
+
+        #Update image reference in csv to use delorean registry
+        sed -i.bak "s|${image}|${delorean_image}|g" $1
+        rm $1.bak
+
+        #Add the image mapping if it doesn't already exist
+        osbs_delorean_map="${osbs_image} ${delorean_image}"
+        grep -qxF "$osbs_delorean_map" $image_mirror_mapping || echo $osbs_delorean_map >> $image_mirror_mapping
+    done
+}
+
+PRODUCT=$1
+
+process_csv() {
+    echo "~~~~~~"
+    echo "Process CSV images for Product $PRODUCT"
+    echo "~~~~~~"
+
+    current_csv=$(get_current_csv_file $PRODUCT)
+    collect_csv_images $current_csv
+    process_csv_images $current_csv $PRODUCT
+}
+
+process_csv

--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -81,4 +81,9 @@ process_csv() {
     process_csv_images $current_csv $PRODUCT
 }
 
-process_csv
+if [ -z "${MANIFESTS_DIR}" ]; then
+    echo "MANIFEST_DIR is not set!!"
+    exit 1
+else
+    process_csv
+fi

--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -51,14 +51,7 @@ extract_manifests_from_image() {
 }
 
 get_current_csv_filename() {
-  # In the case of 3scale the package name needs to be customised
-  case $PRODUCT in
-  "3scale")
-    CURRENT_CSV_FILE_NAME=${PRODUCT}-operator.package.yaml
-    ;;
-  *)
     CURRENT_CSV_FILE_NAME=${PRODUCT}.package.yaml
-  esac
 }
 
 get_current_csv() {

--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -21,7 +21,6 @@
 set -e
 
 WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-MANIFESTS_DIR=${WORK_DIR}/../../manifests
 MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
 IMAGE=$1
 PRODUCT=$2
@@ -199,4 +198,9 @@ process_image() {
    update_package_yaml
 }
 
-process_image
+if [ -z "${MANIFESTS_DIR}" ]; then
+    echo "MANIFEST_DIR is not set!!"
+    exit 1
+else
+    process_image
+fi

--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -1,0 +1,202 @@
+#!/usr/bin/env bash
+
+# This script extracts the most recent manifests from an image containing a manifests bundle and processes it into a version that works with this operator.
+#
+# Example: Running the script and checking the changes produced using git status
+#
+#$ ./process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-2
+#$ git status
+# Changes not staged for commit:
+#  (use "git add <file>..." to update what will be committed)
+#  (use "git checkout -- <file>..." to discard changes in working directory)
+#
+#	modified:   manifests/integreatly-3scale/3scale.package.yaml
+#
+#Untracked files:
+#  (use "git add <file>..." to include in what will be committed)
+#
+#	manifests/integreatly-3scale/3scale-0.5.0/
+
+
+set -e
+
+WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+MANIFESTS_DIR=${WORK_DIR}/../../manifests
+MANIFEST_TMP_DIR=${MANIFESTS_DIR}/tmp
+IMAGE=$1
+PRODUCT=$2
+
+function ver { printf "%03d%03d%03d%03d" $(echo "$1" | tr '.' ' '); }
+
+catch() {
+    if [ "$1" == "127" ]; then
+        echo "This script depends on the package yq"
+        echo "For installation instructions visit: https://mikefarah.gitbook.io/yq/#install"
+    fi
+    echo "Cleaning up ${MANIFEST_TMP_DIR}"
+    rm -rf ${MANIFEST_TMP_DIR}
+}
+
+trap 'catch $?' EXIT
+
+check_yq() {
+    yq > /dev/null
+}
+
+extract_manifests_from_image() {
+    echo "Creating ${MANIFEST_TMP_DIR} directory"
+    mkdir -p ${MANIFEST_TMP_DIR}
+    echo "Extracting manifests from image '${IMAGE}' to ${MANIFEST_TMP_DIR}"
+    oc image extract $IMAGE --path /manifests/:${MANIFEST_TMP_DIR}
+    ls -la ${MANIFEST_TMP_DIR}
+}
+
+get_current_csv_filename() {
+  # In the case of 3scale the package name needs to be customised
+  case $PRODUCT in
+  "3scale")
+    CURRENT_CSV_FILE_NAME=${PRODUCT}-operator.package.yaml
+    ;;
+  *)
+    CURRENT_CSV_FILE_NAME=${PRODUCT}.package.yaml
+  esac
+}
+
+get_current_csv() {
+    echo "Getting current csv from existing package.yaml"
+    # The sed entry here will need to be fixed up for each product.
+    # The operator versions do not all follow the same syntax
+    case "$PRODUCT" in
+    "fuse-online")
+       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV | sed -e s/^fuse-online-operator.v//)
+       ;;
+    "3scale")
+       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV | sed -e s/^3scale-operator.v//)
+       ;;
+    "amq-online")
+       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV | sed -e s/^amqonline.//)
+       ;;
+     *)
+       echo "Passed an unknown product $PRODUCT"
+       exit
+       ;;
+    esac
+    echo "Current CSV $CURRENT_CSV"
+}
+
+
+get_new_csv() {
+    IMAGE_MANIFEST_FILE=$(find ${MANIFEST_TMP_DIR} -name "*.package.yaml")
+    # Get CSV case statement below as there are some differences in the amq-online package.yaml
+    # Read more about it here: https://issues.redhat.com/browse/DEL-62?focusedCommentId=13985142&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-13985142
+    case $PRODUCT in
+    "fuse-online" | "3scale")
+        DEFAUlT_CHANNEL=$(yq r ${IMAGE_MANIFEST_FILE} defaultChannel)
+        NEW_CSV=$(yq r ${IMAGE_MANIFEST_FILE} channels.\(name==${DEFAUlT_CHANNEL}\).currentCSV)
+        ;;
+    "amq-online")
+        NEW_CSV=$(yq r ${IMAGE_MANIFEST_FILE} channels.\(name==stable\).currentCSV)
+        ;;
+    *)
+      echo "Passed an unknown product $PRODUCT"
+      exit
+    esac
+    # The sed entry here will need to be fixed up for each product.
+    # The operator versions do not all follow the same syntax
+    case $PRODUCT in
+    "fuse-online")
+      NEW_CSV_SEMVER=$(echo ${NEW_CSV} | sed s/^fuse-online-operator.v//)
+      ;;
+    "3scale")
+      NEW_CSV_SEMVER=$(echo ${NEW_CSV} | sed s/^3scale-operator.v//)
+      ;;
+    "amq-online")
+      NEW_CSV_SEMVER=$(echo $NEW_CSV | sed -e s/^amq-online.//)
+      ;;
+    *)
+      echo "Passed an unknown product $PRODUCT"
+      exit
+    esac
+    echo "New CSV $NEW_CSV_SEMVER"
+ 
+}
+
+check_versions() {
+    if [ $(ver $NEW_CSV_SEMVER) -eq $(ver $CURRENT_CSV) ]
+    then
+        echo "Versions are the same so EXIT"
+        exit
+    fi
+    if [ $(ver $NEW_CSV_SEMVER) -lt $(ver $CURRENT_CSV) ]
+    then
+        echo "There is a newer version of the CSV present so EXIT"
+        exit
+    fi
+    echo "Newer version found, continuing"
+}
+
+copy_new_csv() {
+    echo "Copying process manifests to ${MANIFESTS_DIR}"
+    # The below line won't work for apicurito as it doesn't add the product name to the semver in it's folder structure
+    NEW_CSV_FOLDER=${PRODUCT}-$NEW_CSV_SEMVER
+    mv ${MANIFEST_TMP_DIR}/${NEW_CSV_SEMVER} ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER}
+    #Delete the target directory if it already exists
+    rm -rf ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}
+    mv ${MANIFEST_TMP_DIR}/${NEW_CSV_FOLDER} ${MANIFESTS_DIR}/integreatly-${PRODUCT}/
+}
+
+get_file_name_for_new_csv() {
+  # In the case of 3scale the package name needs to be customised	
+  case $PRODUCT in
+  "3scale" | "fuse-online")
+    NEW_CSV_FILE_NAME=${PRODUCT}-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml
+    ;;
+  "amq-online")
+    NEW_CSV_FILE_NAME=${PRODUCT}.$NEW_CSV_SEMVER.clusterserviceversion.yaml
+    ;;
+  esac
+}
+
+
+update_new_csv() {
+    echo "updating csv"
+    case $PRODUCT in
+    "fuse-online" | "3scale")
+        DEFAUlT_CHANNEL=$(yq r ${IMAGE_MANIFEST_FILE} defaultChannel)
+        NEW_CSV=$(yq r ${IMAGE_MANIFEST_FILE} channels.\(name==${DEFAUlT_CHANNEL}\).currentCSV)
+        ;;
+    "amq-online")
+        NEW_CSV=$(yq r ${IMAGE_MANIFEST_FILE} channels.\(name==stable\).currentCSV)
+        ;;
+    *)
+      echo "Passed an unknown product $PRODUCT"
+      exit
+    esac
+    echo "${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME}"
+    yq d -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} spec.replaces
+    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==WATCH_NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
+    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
+}
+
+
+update_package_yaml() {
+    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${PRODUCT}.package.yaml channels.\(name==rhmi\).currentCSV $NEW_CSV
+}
+
+process_image() {
+   check_yq
+   echo "~~~~~~"
+   echo "Process Image '$IMAGE'"
+   echo "~~~~~~"
+   extract_manifests_from_image
+   get_current_csv_filename
+   get_current_csv
+   get_new_csv
+   check_versions
+   copy_new_csv
+   get_file_name_for_new_csv
+   update_new_csv
+   update_package_yaml
+}
+
+process_image


### PR DESCRIPTION
Moves all the delorean ews scrips that were once in the delorean-ews branch of the operator into this repo.

Note: These will be removed once the work to migrate them all to Golang is complete.

**Verification:**

```
MANIFESTS_DIR=/home/mnairn/go/src/github.com/integr8ly/integreatly-operator/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-39 3scale
MANIFESTS_DIR=/home/mnairn/go/src/github.com/integr8ly/integreatly-operator/manifests ./scripts/delorean/process-csv-images 3scale
MANIFESTS_DIR=/home/mnairn/go/src/github.com/integr8ly/integreatly-operator/manifests ./scripts/delorean/mirror-images.sh
```


