### PR TITLE
add imagePullSecret to csv

### DIFF
--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -28,6 +28,7 @@ RH_REGISTRY_PROD=registry.redhat.io
 RH_REGISTRY_STAGE=registry.stage.redhat.io
 RH_REGISTRY_OSBS=registry-proxy.engineering.redhat.com/rh-osbs
 DELOREAN_REGISTRY=quay.io/integreatly/delorean
+IMAGE_PULL_SECRET=integreatly-delorean-pull-secret
 
 collect_csv_images() {
     csv_images=(`grep -o ''${RH_REGISTRY_PROD}'.*\|'${RH_REGISTRY_STAGE}'.*' $1 | sed 's/"//' || true`)
@@ -69,6 +70,17 @@ process_csv_images() {
     done
 }
 
+update_image_pull_secret() {
+  current_csv=$(get_current_csv_file $PRODUCT)
+  case $PRODUCT in
+  "amq-online")
+    yq w -i ${current_csv} spec.install.spec.deployments[0].spec.template.spec.imagePullSecrets[0].name ${IMAGE_PULL_SECRET}
+    ;;
+  *)
+    echo "skipping pull secret"
+  esac
+}
+
 PRODUCT=$1
 
 process_csv() {
@@ -86,4 +98,7 @@ if [ -z "${MANIFESTS_DIR}" ]; then
     exit 1
 else
     process_csv
+    if [[ -s ${MANIFESTS_DIR}/integreatly-${PRODUCT}/image_mirror_mapping ]]; then
+      update_image_pull_secret
+    fi
 fi


### PR DESCRIPTION
The deploymentconfig and subsequent pods created by the csv by default reference an imagePullSecret which will not contain the correct credentials.

We must add an imagePullSecret var to ensure the pods created are able to pull the images.