### PR TITLE
adding slash to pick up images only

### DIFF
--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -24,8 +24,8 @@ WORK_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 source $WORK_DIR/csv_helper
 
-RH_REGISTRY_PROD=registry.redhat.io
-RH_REGISTRY_STAGE=registry.stage.redhat.io
+RH_REGISTRY_PROD=registry.redhat.io/
+RH_REGISTRY_STAGE=registry.stage.redhat.io/
 RH_REGISTRY_OSBS=registry-proxy.engineering.redhat.com/rh-osbs
 DELOREAN_REGISTRY=quay.io/integreatly/delorean
 IMAGE_PULL_SECRET=integreatly-delorean-pull-secret


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/DEL-190

**Verification**
Verification below includes the steps for 3 products but fuse was the one seeing the issue.
In all cases the images should be picked up and processed as usual

_fuse-online_
`MANIFEST_DIR=<manifest-dir> ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.6-15 fuse-online
`
`MANIFEST_DIR=<manifest-dir> ./scripts/delorean/process-csv-images fuse-online`

_3scale_
`MANIFEST_DIR=<manifest-dir> ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-26 3scale`
`MANIFEST_DIR=<manifest-dir> ./scripts/delorean/process-csv-images 3scale`

_amq-online_
`MANIFEST_DIR=<manifest-dir> ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/amq7-amq-online-1-controller-manager-rhel7-operator-metadata:1.4-25 amq-online`
`MANIFEST_DIR=<manifest-dir> ./scripts/delorean/process-csv-images amq-online`

