### PR TITLE
only add mapping when osbs image isn't already found

### DIFF
--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -66,7 +66,7 @@ process_csv_images() {
 
         #Add the image mapping if it doesn't already exist
         osbs_delorean_map="${osbs_image} ${delorean_image}"
-        grep -qxF "$osbs_delorean_map" $image_mirror_mapping || echo $osbs_delorean_map >> $image_mirror_mapping
+        grep -qF ${osbs_image} $image_mirror_mapping || echo $osbs_delorean_map >> $image_mirror_mapping
     done
 }
 


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/DEL-195

**Verification**
_1) No existing mapping file_
Check that it works initially when there is no pre-existing image mapping
Remove any changes locally to the manifest folder for 3scale 0.5.0 if any.

Run the expected pipeline steps:
```
MANIFESTS_DIR=<your manifest dir> ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-26 3scale
```
```
MANIFESTS_DIR=<your manifest dir> ./scripts/delorean/process-csv-images 3scale
```

You should have a fresh copy of the 0.5.0 3scale csv with a mapping file containing the expected 9 mappings.

_2) existing mapping file_
Remove any changes locally to the manifest folder for 3scale 0.5.0 **excluding the mapping, leave that in place**


Run the expected pipeline steps:
```
MANIFESTS_DIR=<your manifest dir> ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-26 3scale
```
```
MANIFESTS_DIR=<your manifest dir> ./scripts/delorean/process-csv-images 3scale
```

Verify that there are no additional mappings in the mapping file. There should still be 9.


