### PR TITLE
Updates around the generation of the image mirror mapping files to avoid conflicts

### DIFF
--- a/scripts/delorean/csv_helper
+++ b/scripts/delorean/csv_helper
@@ -12,3 +12,7 @@ get_current_csv() {
 get_current_csv_file() {
     echo "$(grep -lR "name: $(get_current_csv $1)" ${MANIFESTS_DIR}/integreatly-$1)"
 }
+
+get_current_version() {
+    echo "$(yq r "$(get_current_csv_file $1)" spec.version)"
+}

--- a/scripts/delorean/image-whitelist
+++ b/scripts/delorean/image-whitelist
@@ -1,0 +1,1 @@
+registry.redhat.io/openshift4/ose-oauth-proxy:4.2

--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -29,6 +29,7 @@ RH_REGISTRY_STAGE=registry.stage.redhat.io/
 RH_REGISTRY_OSBS=registry-proxy.engineering.redhat.com/rh-osbs
 DELOREAN_REGISTRY=quay.io/integreatly/delorean
 IMAGE_PULL_SECRET=integreatly-delorean-pull-secret
+IMAGE_WHITELIST=$WORK_DIR/image-whitelist
 
 collect_csv_images() {
     csv_images=(`grep -o ''${RH_REGISTRY_PROD}'.*:.*\|'${RH_REGISTRY_STAGE}'.*:.*' $1 | sed 's/"//' || true`)
@@ -53,6 +54,12 @@ process_csv_images() {
     for image in "${csv_images[@]}"
     do
         echo "Processing image $image"
+
+        if grep -q "$image" "$IMAGE_WHITELIST"; then
+            echo "image "$image" is whitelisted, ignoring!"
+            continue
+        fi
+
         # The below logic is specific to the amq-broker image
         if [[ $image == *"amq-broker"* ]]; then
             image_version="$(echo $image | cut -f2 -d":")"

--- a/scripts/delorean/process-csv-images
+++ b/scripts/delorean/process-csv-images
@@ -31,12 +31,24 @@ DELOREAN_REGISTRY=quay.io/integreatly/delorean
 IMAGE_PULL_SECRET=integreatly-delorean-pull-secret
 
 collect_csv_images() {
-    csv_images=(`grep -o ''${RH_REGISTRY_PROD}'.*\|'${RH_REGISTRY_STAGE}'.*' $1 | sed 's/"//' || true`)
+    csv_images=(`grep -o ''${RH_REGISTRY_PROD}'.*:.*\|'${RH_REGISTRY_STAGE}'.*:.*' $1 | sed 's/"//' || true`)
 }
 
 process_csv_images() {
     echo "Generate Image Mirror Mapping for $2"
     image_mirror_mapping=${MANIFESTS_DIR}/integreatly-${2}/image_mirror_mapping
+
+    if [ -f "$image_mirror_mapping" ]; then
+        echo "$image_mirror_mapping exists"
+        if grep -q "$DELOREAN_REGISTRY" "$1"; then
+            echo "$1 contains references to $DELOREAN_REGISTRY"
+        else
+            rm $image_mirror_mapping
+            echo "$1 does not contain references to $DELOREAN_REGISTRY"
+        fi
+    else
+        echo "$image_mirror_mapping does not exist"
+    fi
 
     for image in "${csv_images[@]}"
     do

--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -114,11 +114,6 @@ get_new_csv() {
 }
 
 check_versions() {
-    if [ $(ver $NEW_CSV_SEMVER) -eq $(ver $CURRENT_CSV) ]
-    then
-        echo "Versions are the same so EXIT"
-        exit
-    fi
     if [ $(ver $NEW_CSV_SEMVER) -lt $(ver $CURRENT_CSV) ]
     then
         echo "There is a newer version of the CSV present so EXIT"
@@ -138,7 +133,7 @@ copy_new_csv() {
 }
 
 get_file_name_for_new_csv() {
-  # In the case of 3scale the package name needs to be customised	
+  # In the case of 3scale the package name needs to be customised
   case $PRODUCT in
   "3scale" | "fuse-online")
     NEW_CSV_FILE_NAME=${PRODUCT}-operator.v$NEW_CSV_SEMVER.clusterserviceversion.yaml


### PR DESCRIPTION
* Remove image_mirror_mapping file before re-generating it, but only if the CSV has no references to delorean images.
* Remove check for version equality when extracting manifests from image, we need to update even if the version is the same to ensure we get any updates for pre release versions (operand sha updates etc..).
*  Add image-whitelist, during image processing if the target image exists in this file it will be left as is in the CSV.

