### PR TITLE
update spec.replaces rather than removing it

### DIFF
--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -56,24 +56,25 @@ get_current_csv_filename() {
 
 get_current_csv() {
     echo "Getting current csv from existing package.yaml"
-    # The sed entry here will need to be fixed up for each product.
     # The operator versions do not all follow the same syntax
+    # The passed value below will need to be fixed up for each product.
+    # In particular when we are based on master the amqonline. should be updated to amq-online because of the below change
+    # https://github.com/integr8ly/integreatly-operator/pull/562/files#diff-f0c5f7cdabef76c7adc5c25f5615162cL4
     case "$PRODUCT" in
-    "fuse-online")
-       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV | sed -e s/^fuse-online-operator.v//)
-       ;;
-    "3scale")
-       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV | sed -e s/^3scale-operator.v//)
+    "fuse-online" | "3scale")
+       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV)
+       CURRENT_CSV_SEMVER=$(echo ${CURRENT_CSV} | sed -e s/^${PRODUCT}-operator.v//)
        ;;
     "amq-online")
-       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV | sed -e s/^amqonline.//)
+       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV)
+       CURRENT_CSV_SEMVER=$(echo ${CURRENT_CSV} | sed -e s/^amqonline.// | sed -e s/^amq-online.//)
        ;;
      *)
        echo "Passed an unknown product $PRODUCT"
        exit
        ;;
     esac
-    echo "Current CSV $CURRENT_CSV"
+    echo "Current CSV $CURRENT_CSV_SEMVER"
 }
 
 
@@ -114,7 +115,7 @@ get_new_csv() {
 }
 
 check_versions() {
-    if [ $(ver $NEW_CSV_SEMVER) -lt $(ver $CURRENT_CSV) ]
+    if [ $(ver $NEW_CSV_SEMVER) -lt $(ver $CURRENT_CSV_SEMVER) ]
     then
         echo "There is a newer version of the CSV present so EXIT"
         exit
@@ -160,7 +161,7 @@ update_new_csv() {
       exit
     esac
     echo "${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME}"
-    yq d -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} spec.replaces
+    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.replaces' $CURRENT_CSV
     yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==WATCH_NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
     yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
 }

--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -58,16 +58,13 @@ get_current_csv() {
     echo "Getting current csv from existing package.yaml"
     # The operator versions do not all follow the same syntax
     # The passed value below will need to be fixed up for each product.
-    # In particular when we are based on master the amqonline. should be updated to amq-online because of the below change
-    # https://github.com/integr8ly/integreatly-operator/pull/562/files#diff-f0c5f7cdabef76c7adc5c25f5615162cL4
+    CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV)
     case "$PRODUCT" in
     "fuse-online" | "3scale")
-       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV)
        CURRENT_CSV_SEMVER=$(echo ${CURRENT_CSV} | sed -e s/^${PRODUCT}-operator.v//)
        ;;
     "amq-online")
-       CURRENT_CSV=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${CURRENT_CSV_FILE_NAME} channels[0].currentCSV)
-       CURRENT_CSV_SEMVER=$(echo ${CURRENT_CSV} | sed -e s/^amqonline.// | sed -e s/^amq-online.//)
+       CURRENT_CSV_SEMVER=$(echo ${CURRENT_CSV} | sed -e s/^${PRODUCT}.//)
        ;;
      *)
        echo "Passed an unknown product $PRODUCT"

--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -75,6 +75,8 @@ get_current_csv() {
        ;;
     esac
     echo "Current CSV $CURRENT_CSV_SEMVER"
+    CURRENT_SPEC_REPLACES=$(yq r ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${PRODUCT}-${CURRENT_CSV_SEMVER}/${CURRENT_CSV}.clusterserviceversion.yaml 'spec.replaces')
+    echo "Current spec.replaces ${CURRENT_SPEC_REPLACES}"
 }
 
 
@@ -123,6 +125,21 @@ check_versions() {
     echo "Newer version found, continuing"
 }
 
+get_spec_replaces(){
+    if [ $(ver $NEW_CSV_SEMVER) -eq $(ver $CURRENT_CSV_SEMVER) ]
+    then
+        # In cases where the csv is the same but the files require an update
+        # the spec.replaces will remain the same as what's listed in the previous csv
+        # NOT the new replaces present in the extracted manifest"
+        # As the whole file is replaced by what's extracted we still need to carry out the patch
+        # But with the CURRENT_SPEC_REPLACES sourced before any files are overwritten.
+        SPEC_REPLACES=${CURRENT_SPEC_REPLACES}
+    else
+        SPEC_REPLACES=${CURRENT_CSV}
+    fi
+    echo "Value spec.replaces will be patched: ${SPEC_REPLACES}"
+}
+
 copy_new_csv() {
     echo "Copying process manifests to ${MANIFESTS_DIR}"
     # The below line won't work for apicurito as it doesn't add the product name to the semver in it's folder structure
@@ -161,7 +178,7 @@ update_new_csv() {
       exit
     esac
     echo "${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME}"
-    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.replaces' $CURRENT_CSV
+    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.replaces' ${SPEC_REPLACES}
     yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==WATCH_NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
     yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
 }
@@ -181,6 +198,7 @@ process_image() {
    get_current_csv
    get_new_csv
    check_versions
+   get_spec_replaces
    copy_new_csv
    get_file_name_for_new_csv
    update_new_csv


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/DEL-211

**Changes**
- [x] Case 1: New manifest has a version greater than the previous one
This means a new folder is created and the old version of the csv can be used as replaces 

- [x] Case 2: New manifest has the same version as the previous one.
This means the folder is updated. In that case the replaces should remain the same as what is was before. At the moment it's being overwritten by what's in the tmp/manifest. 

**Products**
- [x] fuse-online
- [x] amq-online
- [x] 3scale

**Verification**
_3scale_
Steps:
1. Check out `integreatly-operator` to the `delorean-ews` branch and ensure no changes.

2. Run `MANIFESTS_DIR=<your-path-to>//integreatly-operator/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-66 3scale`

3. Verify that a new manifest dir is created `3scale-0.5.1`

4. Verify `cat manifests/integreatly-3scale/3scale-0.5.1/3scale-operator.v0.5.1.clusterserviceversion.yaml | grep replaces` produces `replaces: 3scale-operator.v0.4.0`

5. Capture the current state with `git add .` in integreatly-operator folder

6. Run `MANIFESTS_DIR=<your-path-to>/integreatly-operator/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-68 3scale`

7. Verify `cat manifests/integreatly-3scale/3scale-0.5.1/3scale-operator.v0.5.1.clusterserviceversion.yaml | grep replaces` still produces `replaces: 3scale-operator.v0.4.0`

_fuse-online_
Steps:
1. Check out `integreatly-operator` to the `delorean-ews` branch and ensure no changes.

2. Run `MANIFESTS_DIR=<your-path-to>/integreatly-operator/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.6-10 fuse-online`

3. Verify that a new manifest dir is created `fuse-online-7.6.0`

4. Verify `cat manifests/integreatly-fuse-online/fuse-online-7.6.0/fuse-online-operator.v7.6.0.clusterserviceversion.yaml | grep replaces` produces  `replaces: fuse-online-operator.v7.5.0`

5. Capture the current state with `git add .` in integreatly-operator folder

6. Run `MANIFESTS_DIR=<your-path-to>/integreatly-operator/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.6-18 fuse-online`

7. Verify `cat manifests/integreatly-fuse-online/fuse-online-7.6.0/fuse-online-operator.v7.6.0.clusterserviceversion.yaml | grep replaces` produces  `replaces: fuse-online-operator.v7.5.0` also `git diff` will produce the new changes to the csv.

_amq-online_
Steps:
1. Check out `integreatly-operator` to the `delorean-ews` branch and ensure no changes.

2. Run `MANIFESTS_DIR=<your-path-to>/integreatly-operator/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/amq7-amq-online-1-controller-manager-rhel7-operator-metadata:1.4-35 amq-online`

3. Verify `cat manifests/integreatly-amq-online/amq-online-1.4.0/amq-online.1.4.0.clusterserviceversion.yaml | grep replaces` produces ` replaces: amqonline.1.3.1` 

4. You can check there were changes to the csv by running `git diff` but as the manifest version didn't change the replaces also didn't change.
 
