### PR TITLE
don't patch spec.replaces when there wasn't one previously

### DIFF
--- a/scripts/delorean/process-image-manifests
+++ b/scripts/delorean/process-image-manifests
@@ -134,7 +134,6 @@ get_spec_replaces(){
     else
         SPEC_REPLACES=${CURRENT_CSV}
     fi
-    echo "Value spec.replaces will be patched: ${SPEC_REPLACES}"
 }
 
 copy_new_csv() {
@@ -175,7 +174,7 @@ update_new_csv() {
       exit
     esac
     echo "${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME}"
-    yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.replaces' ${SPEC_REPLACES}
+    [ -z "${SPEC_REPLACES}" ] || yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.replaces' ${SPEC_REPLACES}
     yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==WATCH_NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
     yq w -i ${MANIFESTS_DIR}/integreatly-${PRODUCT}/${NEW_CSV_FOLDER}/${NEW_CSV_FILE_NAME} 'spec.install.spec.deployments[0].spec.template.spec.containers[0].env.name==NAMESPACE.valueFrom.fieldRef.fieldPath' metadata.annotations[\'olm.targetNamespaces\']
 }


### PR DESCRIPTION
**JIRA**
https://issues.redhat.com/browse/DEL-211

Check if there's a value in SPEC_REPLACES before attempting a patch

Verification.

1. Checkout master of integreatly-operator.
2. Run: `MANIFESTS_DIR=<your-path-to-integreatly-operator>/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.5-19 fuse-online`
3. git diff on integreatly-operator
4. Verify 
4.1. there are changes to the manifest version fuse-online 7.5.0
4.2 that `cat manifests/integreatly-fuse-online/fuse-online-7.5.0/fuse-online-operator.v7.5.0.clusterserviceversion.yaml| grep replaces` has no output.
4.3 The script didn't break

This is expected. There is no replaces value as there is no previous version in the manifest dir pre 7.5.0

5. Run `MANIFESTS_DIR=<your-path-to-integreatly-operator>/manifests ./scripts/delorean/process-image-manifests registry-proxy.engineering.redhat.com/rh-osbs/fuse7-fuse-online-operator:1.6-19 fuse-online`
6. Verify
6.1 New 7.6.0 manifest dir for fuse-online 
6.2 `cat manifests/integreatly-fuse-online/fuse-online-7.6.0/fuse-online-operator.v7.6.0.clusterserviceversion.yaml| grep replaces` produces ` replaces: fuse-online-operator.v7.5.0`