### PR TITLE
fix: apply latest changes from rhmi-utils repo

### DIFF
--- a/docs/ocm/README.md
+++ b/docs/ocm/README.md
@@ -4,7 +4,7 @@ If you want to test your changes on a cluster, the easiest solution would be to 
 
 #### Prerequisites
 * [OCM CLI](https://github.com/openshift-online/ocm-cli/releases)
-* [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
+* [AWS CLI v1.18](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 * [jq](https://stedolan.github.io/jq/)
 * :apple: (Mac users) - install `gtimeout` util and create a symbolic link (so it can be referenced as `timeout`): 
   * `brew install coreutils && sudo ln -s /usr/local/bin/gtimeout /usr/local/bin/timeout`
@@ -19,8 +19,8 @@ make ocm/login
 ```
 
 **BYOC**
-Make sure you have credentials for IAM user with admin access to AWS and other IAM user called "osdCcsAdmin" created in AWS, also with admin access.
-Export the credentials for your IAM user, set BYOC variable to `true` and create a new access key for "osdCcsAdmin" user:
+Make sure you have credentials for **your own IAM user** with admin access to AWS and **other IAM user called "osdCcsAdmin"** created in AWS, also with admin access.
+Export the credentials for **your own IAM user**, set BYOC variable to `true` and create a new access key for "osdCcsAdmin" user:
 ```
 export AWS_ACCOUNT_ID=<REPLACE_ME>
 export AWS_ACCESS_KEY_ID=<REPLACE_ME>

--- a/templates/ocm/cluster-storage-quota.json
+++ b/templates/ocm/cluster-storage-quota.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "quota.openshift.io/v1",
+    "kind": "ClusterResourceQuota",
+    "metadata": {
+        "name": "rhmi-persistent-volume-quota"
+    },
+    "spec": {
+        "quota": {
+            "hard": {
+                "requests.storage": "100Gi"
+            }
+        },
+        "selector": {
+            "annotations": null,
+            "labels": {
+                "matchExpressions": [
+                    {
+                        "key": "managed.openshift.io/storage-pv-quota-exempt",
+                        "operator": "DoesNotExist"
+                    }
+                ]
+            }
+        }
+    }
+}

--- a/templates/ocm/cr-aws-strategies.yml
+++ b/templates/ocm/cr-aws-strategies.yml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-resources-aws-strategies
+  namespace: redhat-rhmi-operator
+data:
+  blobstorage: |
+    {"production": { "createStrategy": {}, "deleteStrategy": {} }}
+  postgres: |
+    {"production": { "createStrategy": {"PreferredMaintenanceWindow":"sun:23:00-mon:01:30","PreferredBackupWindow":"02:00-02:30"}, "deleteStrategy": {} }}
+  redis: |
+    {"production": { "createStrategy": {"PreferredMaintenanceWindow":"sun:23:00-mon:01:30","SnapshotWindow":"02:00-03:00"}, "deleteStrategy": {} }}

--- a/templates/ocm/load-balancer-cluster-quota.json
+++ b/templates/ocm/load-balancer-cluster-quota.json
@@ -1,0 +1,25 @@
+{
+    "apiVersion": "quota.openshift.io/v1",
+    "kind": "ClusterResourceQuota",
+    "metadata": {
+        "name": "rhmi-loadbalancer-quota"
+    },
+    "spec": {
+        "quota": {
+            "hard": {
+                "services.loadbalancers": "0"
+            }
+        },
+        "selector": {
+            "annotations": null,
+            "labels": {
+                "matchExpressions": [
+                    {
+                        "key": "managed.openshift.io/service-lb-quota-exempt",
+                        "operator": "DoesNotExist"
+                    }
+                ]
+            }
+        }
+    }
+}


### PR DESCRIPTION
### What

Apply latest updates to ocm tooling from rhmi-utils repo so the pipelines can start using delorean repository and the tooling can be removed from rhmi-utils repo.

https://github.com/integr8ly/rhmi-utils/pull/31
https://github.com/integr8ly/rhmi-utils/pull/32
https://github.com/integr8ly/rhmi-utils/pull/33