### PR TITLE
Del 223 release repo

### DIFF
--- a/cmd/openshiftCIRelease.go
+++ b/cmd/openshiftCIRelease.go
@@ -1,0 +1,390 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/google/go-github/v30/github"
+	"github.com/integr8ly/delorean/pkg/services"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultOpenshiftCIRepo    = "release"
+	DefaultOpenshiftCIOrg     = "openshift"
+	DefaultOpenshiftCIOrgFork = "integr8ly"
+)
+
+type openshiftCIReleaseCmdFlags struct {
+	tag                string
+	openshiftCIRepo    string
+	openshiftCIOrg     string
+	openshiftCIOrgFork string
+}
+
+type openshiftCIReleaseCmd struct {
+	version             *utils.RHMIVersion
+	intlyRepoInfo       *githubRepoInfo
+	releaseRepoInfo     *githubRepoInfo
+	releaseRepoForkInfo *githubRepoInfo
+	githubPRService     services.PullRequestsService
+	gitUser             string
+	gitPass             string
+	gitCloneService     services.GitCloneService
+	gitPushService      services.GitPushService
+}
+
+/**
+// Integreatly Operator updates
+//1. Clone the integreatly operator repo and ensure it's on the correct initial minor release tag (v2.1.0, v2.2.0 etc..) for the given tag (v2.1.1, v2.2.1 etc..)
+//2. Create a new release branch with the correct naming we expect (release-v2.1) if one does not already exist
+//3. Push the branch
+*/
+func (c *openshiftCIReleaseCmd) DoIntlyOperatorUpdate(ctx context.Context) (string, error) {
+	//Clone the integreatly operator repo to a temp directory
+	initialReleaseTag := plumbing.NewTagReferenceName(c.version.InitialPointReleaseTag())
+	fmt.Println(fmt.Sprintf("Clone repo from %s/%s/%s.git (%s) to a temporary directory", githubURL, c.intlyRepoInfo.owner, c.intlyRepoInfo.repo, initialReleaseTag.String()))
+	repoDir, gitRepo, err := c.gitCloneService.CloneToTmpDir("integreatly-operator", fmt.Sprintf("%s/%s/%s.git", githubURL, c.intlyRepoInfo.owner, c.intlyRepoInfo.repo), initialReleaseTag)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println("Repo cloned to", repoDir)
+
+	worktree, err := gitRepo.Worktree()
+	if err != nil {
+		return "", err
+	}
+
+	//Ensure release branch exists
+	branch := plumbing.NewBranchReferenceName(c.version.ReleaseBranchName())
+	fmt.Println(fmt.Sprintf("Checkout branch %s", branch))
+	err = worktree.Checkout(&git.CheckoutOptions{Create: false, Force: false, Branch: branch})
+	if err != nil {
+		err := worktree.Checkout(&git.CheckoutOptions{Create: true, Force: false, Branch: branch})
+		if err != nil {
+			return "", nil
+		}
+		fmt.Println(fmt.Sprintf("Created new branch %s", branch))
+
+		pushOpts := &git.PushOptions{
+			RemoteName: "origin",
+			Auth:       &http.BasicAuth{Password: c.gitPass, Username: c.gitUser},
+			Progress:   os.Stdout,
+			RefSpecs: []config.RefSpec{
+				config.RefSpec(branch + ":" + branch),
+			},
+		}
+		if err := c.gitPushService.Push(gitRepo, pushOpts); err != nil {
+			return "", err
+		}
+		fmt.Println(fmt.Sprintf("Pushed branch %s", branch))
+	}
+
+	return repoDir, nil
+}
+
+/**
+  OpenShift Release updates
+  1. Clone the release repo and ensure it is up to date
+  2. Create configuration in the release repo for this new branch
+  3. Add ci-operator config for branch (https://github.com/openshift/release/blob/master/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml)
+  4. Update promotion config to ensure it pushes the images to the registry with a different tag name (branch name)
+  5. Run Make jobs
+  6. Update image mirroring to include entries for the new release branch https://github.com/openshift/release/blob/master/core-services/image-mirroring/integr8ly/mapping_integr8ly_operator
+  7. Commit all updated and generate configuration
+  8. Open a PR
+*/
+func (c *openshiftCIReleaseCmd) DoOpenShiftReleaseUpdate(ctx context.Context) (string, error) {
+	//Clone the release repo to a temp directory
+	baseBranch := plumbing.NewBranchReferenceName("master")
+	fmt.Println(fmt.Sprintf("Clone repo from %s/%s/%s.git (%s) to a temporary directory", githubURL, c.releaseRepoInfo.owner, c.releaseRepoInfo.repo, baseBranch))
+	repoDir, gitRepo, err := c.gitCloneService.CloneToTmpDir("release", fmt.Sprintf("%s/%s/%s.git", githubURL, c.releaseRepoInfo.owner, c.releaseRepoInfo.repo), baseBranch)
+	if err != nil {
+		return "", err
+	}
+	fmt.Println("Repo cloned to", repoDir)
+
+	//Add remote for release repo fork
+	fork := fmt.Sprintf("%s/%s/%s", githubURL, c.releaseRepoForkInfo.owner, c.releaseRepoForkInfo.repo)
+	_, err = gitRepo.CreateRemote(&config.RemoteConfig{
+		Name: "fork",
+		URLs: []string{fork},
+	})
+	if err != nil {
+		return "", err
+	}
+	fmt.Println(fmt.Sprintf("Added fork remote (%s)", fork))
+
+	worktree, err := gitRepo.Worktree()
+	if err != nil {
+		return "", err
+	}
+
+	//Ensure release branch exists
+	branch := plumbing.NewBranchReferenceName(c.version.ReleaseBranchName())
+	fmt.Println(fmt.Sprintf("Checkout branch %s", branch))
+	err = worktree.Checkout(&git.CheckoutOptions{Create: false, Force: false, Branch: branch})
+	if err != nil {
+		err := worktree.Checkout(&git.CheckoutOptions{Create: true, Force: false, Branch: branch})
+		if err != nil {
+			return "", nil
+		}
+		fmt.Println(fmt.Sprintf("Created new branch %s", branch))
+	}
+
+	//Update CI Operator Config
+	err = updateCIOperatorConfig(repoDir, *c.version)
+	if err != nil {
+		return "", err
+	}
+	commitMsg := fmt.Sprintf("Updated ci operator config for branch %s", branch.Short())
+
+	// Add all changes
+	err = worktree.AddGlob("ci-operator/*")
+	if err != nil {
+		return "", err
+	}
+
+	//Update Image Mirror Mapping Config
+	err = updateImageMirroringConfig(repoDir, *c.version)
+	if err != nil {
+		return "", err
+	}
+	commitMsg += fmt.Sprintf("\nUpdated image mirror mapping config for branch %s", branch.Short())
+
+	// Add all changes
+	err = worktree.AddGlob("core-services/*")
+	if err != nil {
+		return "", err
+	}
+
+	status, err := worktree.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) > 0 {
+		// Commit
+		fmt.Println(commitMsg)
+		_, err = worktree.Commit(
+			commitMsg,
+			&git.CommitOptions{
+				All: true,
+				Author: &object.Signature{
+					Name:  commitAuthorName,
+					Email: commitAuthorEmail,
+					When:  time.Now(),
+				},
+			},
+		)
+		if err != nil {
+			return "", err
+		}
+
+		//Push changes to fork
+		pushOpts := &git.PushOptions{
+			RemoteName: "fork",
+			Auth:       &http.BasicAuth{Password: c.gitPass, Username: c.gitUser},
+			Progress:   os.Stdout,
+			RefSpecs: []config.RefSpec{
+				config.RefSpec(branch + ":" + branch),
+			},
+		}
+		if err := c.gitPushService.Push(gitRepo, pushOpts); err != nil {
+			return "", err
+		}
+		fmt.Println(fmt.Sprintf("Pushed branch %s to %s", branch, fork))
+
+		//Open Pull Request
+		h := fmt.Sprintf("%s:%s", c.releaseRepoForkInfo.owner, branch)
+		b := "master"
+		err = c.createPRIfNotExists(ctx, h, b, branch.Short())
+		if err != nil {
+			return "", err
+		}
+
+	} else {
+		fmt.Println("No new changes found")
+	}
+
+	return repoDir, nil
+}
+
+func (c *openshiftCIReleaseCmd) createPRIfNotExists(ctx context.Context, head, base, branch string) error {
+	prOpts := &github.PullRequestListOptions{Base: base, Head: head}
+	pr, err := findPRForRelease(ctx, c.githubPRService, c.releaseRepoInfo, prOpts)
+	if err != nil && !isPRNotFoundError(err) {
+		return err
+	}
+	if pr == nil {
+		fmt.Println("Create PR for release")
+		title := fmt.Sprintf("Add CI config for RHMI operator branch %s", branch)
+		body := "/cc @mikenairn"
+		req := &github.NewPullRequest{
+			Title: &title,
+			Head:  &head,
+			Base:  &base,
+			Body:  &body,
+		}
+		pr, _, err = c.githubPRService.Create(ctx, c.releaseRepoInfo.owner, c.releaseRepoInfo.repo, req)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Println(fmt.Sprintf("PR created: %s", pr.GetHTMLURL()))
+	return nil
+}
+
+func updateCIOperatorConfig(repoDir string, version utils.RHMIVersion) error {
+	masterConfig := path.Join(repoDir, "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml")
+	releaseConfig := path.Join(repoDir, fmt.Sprintf("ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-%s.yaml", version.ReleaseBranchName()))
+
+	read, err := ioutil.ReadFile(masterConfig)
+	if err != nil {
+		return err
+	}
+
+	masterPromotion := "promotion:\n  name: integreatly-operator"
+	releasePromotion := fmt.Sprintf("promotion:\n  name: \"%s\"", version.MajorMinor())
+	releaseConfigContents := strings.Replace(string(read), masterPromotion, releasePromotion, -1)
+
+	err = ioutil.WriteFile(releaseConfig, []byte(releaseConfigContents), 0644)
+	if err != nil {
+		return err
+	}
+
+	makeExecutable, err := exec.LookPath("make")
+	if err != nil {
+		return err
+	}
+
+	makeJobCmd := &exec.Cmd{
+		Dir:    repoDir,
+		Path:   makeExecutable,
+		Args:   []string{makeExecutable, "jobs"},
+		Stdout: os.Stdout,
+		Stderr: os.Stdout,
+	}
+
+	err = makeJobCmd.Run()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func updateImageMirroringConfig(repoDir string, version utils.RHMIVersion) error {
+	mappingFile := path.Join(repoDir, fmt.Sprintf("core-services/image-mirroring/integr8ly/mapping_integr8ly_operator_%s", strings.ReplaceAll(version.MajorMinor(), ".", "_")))
+
+	internalReg := "registry.svc.ci.openshift.org/integr8ly"
+	publicReg := "quay.io/integreatly"
+
+	imageTemplates := map[string]string{
+		"%s/%s:integreatly-operator":              "%s/integreatly-operator:%s",
+		"%s/%s:integreatly-operator-test-harness": "%s/integreatly-operator-test-harness:%s",
+	}
+
+	file, err := os.Create(mappingFile)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	w := bufio.NewWriter(file)
+
+	for it, pt := range imageTemplates {
+		internalImage := fmt.Sprintf(it, internalReg, version.MajorMinor())
+		publicImage := fmt.Sprintf(pt, publicReg, version.MajorMinor())
+		mapping := fmt.Sprintf("%s %s\n", internalImage, publicImage)
+		w.WriteString(mapping)
+	}
+
+	return w.Flush()
+}
+
+func init() {
+
+	f := &openshiftCIReleaseCmdFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "openshift-ci-release",
+		Short: "Update openshift CI Release repo",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			c, err := newOpenshiftCIReleaseCmd(f)
+			if err != nil {
+				handleError(err)
+			}
+			var intlyOperatorRepoDir string
+			if intlyOperatorRepoDir, err = c.DoIntlyOperatorUpdate(cmd.Context()); err != nil {
+				handleError(err)
+			}
+			if intlyOperatorRepoDir != "" {
+				fmt.Println("Remove temporary directory:", intlyOperatorRepoDir)
+				if err = os.RemoveAll(intlyOperatorRepoDir); err != nil {
+					handleError(err)
+				}
+			}
+			var ciReleaseRepoDir string
+			if ciReleaseRepoDir, err = c.DoOpenShiftReleaseUpdate(cmd.Context()); err != nil {
+				handleError(err)
+			}
+			if ciReleaseRepoDir != "" {
+				fmt.Println("Remove temporary directory:", ciReleaseRepoDir)
+				if err = os.RemoveAll(ciReleaseRepoDir); err != nil {
+					handleError(err)
+				}
+			}
+		},
+	}
+
+	releaseCmd.AddCommand(cmd)
+	cmd.Flags().StringVar(&f.tag, "tag", "", "The release tag")
+	cmd.Flags().StringVar(&f.openshiftCIOrgFork, "ci-org-fork", DefaultOpenshiftCIOrgFork, "OpenShift CI Release GitHub Fork")
+	cmd.Flags().StringVar(&f.openshiftCIOrg, "ci-org", DefaultOpenshiftCIOrg, "OpenShift CI Release GitHub org")
+	cmd.Flags().StringVar(&f.openshiftCIRepo, "ci-repo", DefaultOpenshiftCIRepo, "OpenShift CI Release GitHub repo")
+	cmd.MarkFlagRequired("tag")
+}
+
+func newOpenshiftCIReleaseCmd(f *openshiftCIReleaseCmdFlags) (*openshiftCIReleaseCmd, error) {
+	var token string
+	var err error
+	if token, err = requireValue(GithubTokenKey); err != nil {
+		return nil, err
+	}
+	var user string
+	if user, err = requireValue(GithubUserKey); err != nil {
+		return nil, err
+	}
+	client := newGithubClient(token)
+	intlyRepoInfo := &githubRepoInfo{owner: integreatlyGHOrg, repo: integreatlyOperatorRepo}
+	releaseRepoInfo := &githubRepoInfo{owner: f.openshiftCIOrg, repo: f.openshiftCIRepo}
+	releaseRepoForkInfo := &githubRepoInfo{owner: f.openshiftCIOrgFork, repo: f.openshiftCIRepo}
+	version, err := utils.NewRHMIVersion(f.tag)
+	if err != nil {
+		return nil, err
+	}
+	return &openshiftCIReleaseCmd{
+		version:             version,
+		releaseRepoForkInfo: releaseRepoForkInfo,
+		releaseRepoInfo:     releaseRepoInfo,
+		intlyRepoInfo:       intlyRepoInfo,
+		githubPRService:     client.PullRequests,
+		gitUser:             user,
+		gitPass:             token,
+		gitCloneService:     &services.DefaultGitCloneService{},
+		gitPushService:      &services.DefaultGitPushService{},
+	}, nil
+}

--- a/cmd/openshiftCIRelease_test.go
+++ b/cmd/openshiftCIRelease_test.go
@@ -1,0 +1,482 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-git/go-git/v5/config"
+	"io/ioutil"
+	"os"
+	"path"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/google/go-github/v30/github"
+	"github.com/integr8ly/delorean/pkg/services"
+	"github.com/integr8ly/delorean/pkg/utils"
+)
+
+type mockGitRemoteService struct {
+	createFunc        func(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error)
+	CreateAndPullFunc func(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error)
+}
+
+func (m mockGitRemoteService) Create(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error) {
+	if m.createFunc != nil {
+		return m.createFunc(gitRepo, remoteConfig)
+	}
+	panic("implement me")
+}
+
+func (m mockGitRemoteService) CreateAndPull(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error) {
+	if m.CreateAndPullFunc != nil {
+		return m.CreateAndPullFunc(gitRepo, remoteConfig)
+	}
+	panic("implement me")
+}
+
+func verifyRepo(repoDir, expectedBranch string) (*git.Repository, error) {
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		return nil, err
+	}
+	repoTree, err := repo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+	status, err := repoTree.Status()
+	if err != nil {
+		return nil, err
+	}
+	if len(status) > 0 {
+		return nil, fmt.Errorf("there are uncommited changes in the repo: %v", status)
+	}
+
+	h, err := repo.Head()
+	if err != nil {
+		return nil, err
+	}
+	actualBranch := h.Name().Short()
+	if actualBranch != expectedBranch {
+		return nil, fmt.Errorf("current branch name is incorrect, want: %s, got: %s", expectedBranch, actualBranch)
+	}
+
+	return repo, nil
+}
+
+func Test_updateCIOperatorConfig(t *testing.T) {
+
+	version, _ := utils.NewRHMIVersion("2.0.0-rc1")
+	validReleaseDir := "./testdata/release"
+	validReleaseDirTmp, err := ioutil.TempDir(os.TempDir(), "test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(validReleaseDirTmp)
+
+	err = utils.CopyDirectory(validReleaseDir, validReleaseDirTmp)
+	if err != nil {
+		t.Fatalf("failed to copy the directory %s to %s: %s", validReleaseDir, validReleaseDirTmp, err)
+	}
+
+	type args struct {
+		repoDir string
+		version *utils.RHMIVersion
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		verify  func(releaseDir string) error
+	}{
+		{
+			name: "valid directory",
+			args: args{
+				repoDir: validReleaseDirTmp,
+				version: version,
+			},
+			verify: func(repoDir string) error {
+				content, err := ioutil.ReadFile(path.Join(repoDir, "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.0.yaml"))
+				if err != nil {
+					return err
+				}
+				promotionStr := "promotion:\n  name: \"2.0\""
+				if strings.Index(string(content), "promotion:\n  name: \"2.0\"") < 0 {
+					return fmt.Errorf("missing content: %s", promotionStr)
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "invalid directory",
+			args: args{
+				repoDir: "./testdata",
+				version: version,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := updateCIOperatorConfig(tt.args.repoDir, tt.args.version); (err != nil) != tt.wantErr {
+				t.Errorf("updateCIOperatorConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.verify != nil {
+				if err = tt.verify(tt.args.repoDir); err != nil {
+					t.Fatalf("verification failed due to error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func Test_updateImageMirroringConfig(t *testing.T) {
+
+	version, _ := utils.NewRHMIVersion("2.0.0-rc1")
+	validReleaseDir := "./testdata/release"
+	validReleaseDirTmp, err := ioutil.TempDir(os.TempDir(), "test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(validReleaseDirTmp)
+
+	err = utils.CopyDirectory(validReleaseDir, validReleaseDirTmp)
+	if err != nil {
+		t.Fatalf("failed to copy the directory %s to %s: %s", validReleaseDir, validReleaseDirTmp, err)
+	}
+
+	type args struct {
+		repoDir string
+		version *utils.RHMIVersion
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		verify  func(releaseDir string) error
+	}{
+		{
+			name: "valid directory",
+			args: args{
+				repoDir: validReleaseDirTmp,
+				version: version,
+			},
+			verify: func(repoDir string) error {
+				content, err := ioutil.ReadFile(path.Join(repoDir, "core-services/image-mirroring/integr8ly/mapping_integr8ly_operator_2_0"))
+				if err != nil {
+					return err
+				}
+
+				expectedMappings := "" +
+					"registry.svc.ci.openshift.org/integr8ly/2.0:integreatly-operator " +
+					"quay.io/integreatly/integreatly-operator:2.0\n" +
+					"registry.svc.ci.openshift.org/integr8ly/2.0:integreatly-operator-test-harness " +
+					"quay.io/integreatly/integreatly-operator-test-harness:2.0"
+				if strings.Index(string(content), expectedMappings) < 0 {
+					return fmt.Errorf("expected: %s, got: %s", expectedMappings, string(content))
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "invalid directory",
+			args: args{
+				repoDir: "./testdata",
+				version: version,
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := updateImageMirroringConfig(tt.args.repoDir, tt.args.version); (err != nil) != tt.wantErr {
+				t.Errorf("updateImageMirroringConfig() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.verify != nil {
+				if err = tt.verify(tt.args.repoDir); err != nil {
+					t.Fatalf("verification failed due to error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func Test_openshiftCIReleaseCmd_createPRIfNotExists(t *testing.T) {
+	type fields struct {
+		releaseRepoInfoUpstream *githubRepoInfo
+		githubPRService         services.PullRequestsService
+	}
+	type args struct {
+		ctx   context.Context
+		newPR *github.NewPullRequest
+	}
+	head := "head"
+	base := "base"
+	prURL1 := "http://testurl1"
+	prNumber1 := 1
+	prURL2 := "http://testurl2"
+	prNumber2 := 2
+	testPR1 := &github.PullRequest{HTMLURL: &prURL1, Number: &prNumber1}
+	testPR2 := &github.PullRequest{HTMLURL: &prURL2, Number: &prNumber2}
+
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		want    *github.PullRequest
+		wantErr bool
+	}{
+		{
+			name: "test find existing PR",
+			fields: fields{
+				releaseRepoInfoUpstream: &githubRepoInfo{owner: "test", repo: "test"},
+				githubPRService: mockPullRequestsService{
+					ListFunc: func(ctx context.Context, owner string, repo string, opts *github.PullRequestListOptions) (requests []*github.PullRequest, response *github.Response, err error) {
+						return []*github.PullRequest{testPR1}, nil, nil
+					},
+					GetFunc: func(ctx context.Context, owner string, repo string, number int) (request *github.PullRequest, response *github.Response, err error) {
+						return testPR1, nil, nil
+					},
+					CreateFunc: func(ctx context.Context, owner string, repo string, pull *github.NewPullRequest) (request *github.PullRequest, response *github.Response, err error) {
+						return testPR2, nil, nil
+					},
+				},
+			},
+			args: args{
+				ctx: context.TODO(),
+				newPR: &github.NewPullRequest{
+					Head: &head,
+					Base: &base,
+				},
+			},
+			want: testPR1,
+		},
+		{
+			name: "test create new PR",
+			fields: fields{
+				releaseRepoInfoUpstream: &githubRepoInfo{owner: "test", repo: "test"},
+				githubPRService: mockPullRequestsService{
+					ListFunc: func(ctx context.Context, owner string, repo string, opts *github.PullRequestListOptions) (requests []*github.PullRequest, response *github.Response, err error) {
+						return []*github.PullRequest{}, nil, nil
+					},
+					CreateFunc: func(ctx context.Context, owner string, repo string, pull *github.NewPullRequest) (request *github.PullRequest, response *github.Response, err error) {
+						return testPR2, nil, nil
+					},
+				},
+			},
+			args: args{
+				ctx: context.TODO(),
+				newPR: &github.NewPullRequest{
+					Head: &head,
+					Base: &base,
+				},
+			},
+			want: testPR2,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := &openshiftCIReleaseCmd{
+				releaseRepoInfoUpstream: tt.fields.releaseRepoInfoUpstream,
+				githubPRService:         tt.fields.githubPRService,
+			}
+			got, err := c.createPRIfNotExists(tt.args.ctx, tt.args.newPR)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("openshiftCIReleaseCmd.createPRIfNotExists() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("openshiftCIReleaseCmd.createPRIfNotExists() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_openshiftCIReleaseCmd_DoIntlyOperatorUpdate(t *testing.T) {
+
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name       string
+		version    string
+		args       args
+		wantBranch string
+		wantErr    bool
+		verify     func(repoDir, expectedBranch string) (*git.Repository, error)
+	}{
+		{
+			name:       "test success 2.0.0-rc1",
+			version:    "2.0.0-rc1",
+			wantBranch: "release-v2.0",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+		{
+			name:       "test success 2.0.0",
+			version:    "2.0.0",
+			wantBranch: "release-v2.0",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+		{
+			name:       "test success 2.0.1-rc1",
+			version:    "2.0.1-rc1",
+			wantBranch: "release-v2.0",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+		{
+			name:       "test success 2.1.0-er1",
+			version:    "2.1.0-er1",
+			wantBranch: "release-v2.1",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			version, _ := utils.NewRHMIVersion(tt.version)
+			c := &openshiftCIReleaseCmd{
+				version:       version,
+				intlyRepoInfo: &githubRepoInfo{owner: "test", repo: "test"},
+				gitCloneService: &mockGitCloneService{cloneToTmpDirFunc: func(prefix string, url string, reference plumbing.ReferenceName) (s string, repository *git.Repository, err error) {
+					currentDir, err := os.Getwd()
+					if err != nil {
+						return "", nil, err
+					}
+					return initRepoFromTestDir("test-openshift-ci-release-", path.Join(currentDir, "testdata/createReleaseTest"))
+				}},
+				gitPushService: &mockGitPushService{pushFunc: func(gitRepo *git.Repository, opts *git.PushOptions) error {
+					return nil
+				}},
+			}
+			repoDir, err := c.DoIntlyOperatorUpdate(tt.args.ctx)
+			if repoDir != "" {
+				defer os.RemoveAll(repoDir)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("openshiftCIReleaseCmd.DoIntlyOperatorUpdate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if repoDir == "" {
+				t.Errorf("openshiftCIReleaseCmd.DoIntlyOperatorUpdate() = %v", repoDir)
+			}
+			if tt.verify != nil {
+				if _, err = tt.verify(repoDir, tt.wantBranch); err != nil {
+					t.Fatalf("verification failed due to error: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func Test_openshiftCIReleaseCmd_DoOpenShiftReleaseUpdate(t *testing.T) {
+
+	prURL := "http://testurl1"
+	prNumber := 1
+
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name       string
+		version    string
+		args       args
+		wantBranch string
+		wantErr    bool
+		verify     func(repoDir, expectedBranch string) (*git.Repository, error)
+	}{
+		{
+			name:       "test success 2.0.0-rc1",
+			version:    "2.0.0-rc1",
+			wantBranch: "release-v2.0",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+		{
+			name:       "test success 2.0.0",
+			version:    "2.0.0",
+			wantBranch: "release-v2.0",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+		{
+			name:       "test success 2.0.1-rc1",
+			version:    "2.0.1-rc1",
+			wantBranch: "release-v2.0",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+		{
+			name:       "test success 2.1.0-er1",
+			version:    "2.1.0-er1",
+			wantBranch: "release-v2.1",
+			verify: func(repoDir, expectedBranch string) (*git.Repository, error) {
+				return verifyRepo(repoDir, expectedBranch)
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			version, _ := utils.NewRHMIVersion(tt.version)
+
+			c := &openshiftCIReleaseCmd{
+				version:                 version,
+				releaseRepoInfoOrigin:   &githubRepoInfo{owner: "test", repo: "test"},
+				releaseRepoInfoUpstream: &githubRepoInfo{owner: "test2", repo: "test"},
+				gitCloneService: &mockGitCloneService{cloneToTmpDirFunc: func(prefix string, url string, reference plumbing.ReferenceName) (s string, repository *git.Repository, err error) {
+					currentDir, err := os.Getwd()
+					if err != nil {
+						return "", nil, err
+					}
+					return initRepoFromTestDir("test-openshift-ci-release-", path.Join(currentDir, "testdata/release"))
+				}},
+				gitPushService: &mockGitPushService{pushFunc: func(gitRepo *git.Repository, opts *git.PushOptions) error {
+					return nil
+				}},
+				githubPRService: mockPullRequestsService{
+					ListFunc: func(ctx context.Context, owner string, repo string, opts *github.PullRequestListOptions) (requests []*github.PullRequest, response *github.Response, err error) {
+						return []*github.PullRequest{}, nil, nil
+					},
+					CreateFunc: func(ctx context.Context, owner string, repo string, pull *github.NewPullRequest) (request *github.PullRequest, response *github.Response, err error) {
+						return &github.PullRequest{HTMLURL: &prURL, Number: &prNumber}, nil, nil
+					},
+				},
+				gitRemoteService: mockGitRemoteService{
+					CreateAndPullFunc: func(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error) {
+						return nil, nil
+					},
+				},
+			}
+			repoDir, err := c.DoOpenShiftReleaseUpdate(tt.args.ctx)
+			if repoDir != "" {
+				defer os.RemoveAll(repoDir)
+			}
+			if (err != nil) != tt.wantErr {
+				t.Errorf("openshiftCIReleaseCmd.DoOpenShiftReleaseUpdate() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if repoDir == "" {
+				t.Errorf("openshiftCIReleaseCmd.DoOpenShiftReleaseUpdate() = %v", repoDir)
+			}
+			if tt.verify != nil {
+				if _, err = tt.verify(repoDir, tt.wantBranch); err != nil {
+					t.Fatalf("verification failed due to error: %v", err)
+				}
+			}
+		})
+	}
+}

--- a/cmd/testdata/release/Makefile
+++ b/cmd/testdata/release/Makefile
@@ -1,0 +1,4 @@
+
+jobs:
+	@echo running jobs
+.PHONY: jobs

--- a/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml
+++ b/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml
@@ -1,0 +1,62 @@
+base_images:
+  os:
+    cluster: https://api.ci.openshift.org
+    name: ubi
+    namespace: ocp
+    tag: "8"
+binary_build_commands: make code/compile COMPILE_TARGET="./build/_output/bin/integreatly-operator"
+build_root:
+  image_stream_tag:
+    cluster: https://api.ci.openshift.org
+    name: intly-operator-base-image
+    namespace: integr8ly
+    tag: latest
+images:
+- dockerfile_path: build/Dockerfile
+  from: os
+  inputs:
+    bin:
+      paths:
+      - destination_dir: .
+        source_path: /go/src/github.com/integr8ly/integreatly-operator/build
+  to: integreatly-operator
+- dockerfile_path: Dockerfile.functional
+  from: os
+  to: integreatly-operator-test-harness
+promotion:
+  name: integreatly-operator
+  namespace: integr8ly
+resources:
+  '*':
+    requests:
+      cpu: 100m
+      memory: 250Mi
+  unit:
+    requests:
+      cpu: 200m
+      memory: 2Gi
+tag_specification:
+  cluster: https://api.ci.openshift.org
+  name: "4.3"
+  namespace: ocp
+tests:
+- as: vendor
+  commands: make vendor/check
+  container:
+    from: src
+- as: unit
+  commands: make test/unit
+  container:
+    from: src
+- as: format
+  commands: make code/check
+  container:
+    from: src
+- as: e2e
+  commands: make test/e2e/prow
+  openshift_installer_src:
+    cluster_profile: aws
+- as: manifest
+  commands: make manifest/check
+  container:
+    from: src

--- a/cmd/testdata/release/core-services/image-mirroring/integr8ly/mapping_integr8ly_operator
+++ b/cmd/testdata/release/core-services/image-mirroring/integr8ly/mapping_integr8ly_operator
@@ -1,0 +1,2 @@
+registry.svc.ci.openshift.org/integr8ly/integreatly-operator:integreatly-operator quay.io/integreatly/integreatly-operator:master
+registry.svc.ci.openshift.org/integr8ly/integreatly-operator:integreatly-operator-test-harness quay.io/integreatly/integreatly-operator-test-harness:master

--- a/pkg/services/git_service.go
+++ b/pkg/services/git_service.go
@@ -12,6 +12,11 @@ type GitCloneService interface {
 	CloneToTmpDir(prefix string, url string, reference plumbing.ReferenceName) (string, *git.Repository, error)
 }
 
+type GitRemoteService interface {
+	Create(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error)
+	CreateAndPull(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error)
+}
+
 type GitPushService interface {
 	Push(gitRepo *git.Repository, opts *git.PushOptions) error
 }
@@ -34,9 +39,9 @@ func (s *DefaultGitCloneService) CloneToTmpDir(prefix string, url string, refere
 	}
 
 	err = repo.Fetch(&git.FetchOptions{
-		RefSpecs: []config.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
+		RefSpecs: []config.RefSpec{"refs/*:refs/*"},
 	})
-	if err != nil {
+	if err != nil && err.Error() != "already up-to-date" {
 		return "", nil, err
 	}
 
@@ -44,7 +49,33 @@ func (s *DefaultGitCloneService) CloneToTmpDir(prefix string, url string, refere
 }
 
 type DefaultGitPushService struct{}
+type DefaultGitRemoteService struct{}
 
 func (s *DefaultGitPushService) Push(gitRepo *git.Repository, opts *git.PushOptions) error {
 	return gitRepo.Push(opts)
+}
+
+func (s *DefaultGitRemoteService) Create(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error) {
+	return gitRepo.CreateRemote(remoteConfig)
+}
+
+func (s *DefaultGitRemoteService) CreateAndPull(gitRepo *git.Repository, remoteConfig *config.RemoteConfig) (*git.Remote, error) {
+
+	remote, err := gitRepo.CreateRemote(remoteConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	worktree, err := gitRepo.Worktree()
+	if err != nil {
+		return nil, err
+	}
+
+	//Pull remote into current branch
+	err = worktree.Pull(&git.PullOptions{RemoteName: remoteConfig.Name})
+	if err != nil {
+		return nil, err
+	}
+
+	return remote, err
 }

--- a/pkg/services/git_service.go
+++ b/pkg/services/git_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/config"
 	"github.com/go-git/go-git/v5/plumbing"
 	"io/ioutil"
 	"os"
@@ -27,6 +28,13 @@ func (s *DefaultGitCloneService) CloneToTmpDir(prefix string, url string, refere
 		URL:           url,
 		ReferenceName: reference,
 		Progress:      os.Stdout,
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	err = repo.Fetch(&git.FetchOptions{
+		RefSpecs: []config.RefSpec{"refs/*:refs/*", "HEAD:refs/heads/HEAD"},
 	})
 	if err != nil {
 		return "", nil, err

--- a/pkg/utils/rhmi_version.go
+++ b/pkg/utils/rhmi_version.go
@@ -48,7 +48,7 @@ func (v *RHMIVersion) IsPreRrelease() bool {
 }
 
 func (v *RHMIVersion) ReleaseBranchName() string {
-	return fmt.Sprintf("release-v%s", v.base)
+	return fmt.Sprintf("release-v%s", v.MajorMinor())
 }
 
 func (v *RHMIVersion) TagName() string {
@@ -61,4 +61,13 @@ func (v *RHMIVersion) Base() string {
 
 func (v *RHMIVersion) Build() string {
 	return v.build
+}
+
+func (v *RHMIVersion) InitialPointReleaseTag() string {
+	return fmt.Sprintf("v%s.0", v.MajorMinor())
+}
+
+func (v *RHMIVersion) MajorMinor() string {
+	parts := strings.Split(v.base, ".")
+	return fmt.Sprintf("%s.%s", parts[0], parts[1])
 }

--- a/pkg/utils/rhmi_version_test.go
+++ b/pkg/utils/rhmi_version_test.go
@@ -17,7 +17,7 @@ func TestReleaseVersion(t *testing.T) {
 		{
 			description: "Verify release version",
 			version:     "2.0.0",
-			branchName:  "release-2.0",
+			branchName:  "release-v2.0",
 			tagName:     "v2.0.0",
 			preRelease:  false,
 			expectError: false,
@@ -25,7 +25,7 @@ func TestReleaseVersion(t *testing.T) {
 		{
 			description: "Verify pre release version",
 			version:     "2.0.0-ER1",
-			branchName:  "release-2.0",
+			branchName:  "release-v2.0",
 			tagName:     "v2.0.0-ER1",
 			preRelease:  true,
 			expectError: false,
@@ -123,6 +123,62 @@ func TestRHMIVersion_InitialPointReleaseTag(t *testing.T) {
 			}
 			if got := v.InitialPointReleaseTag(); got != tt.want {
 				t.Errorf("RHMIVersion.InitialPointReleaseTag() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRHMIVersion_MajorMinor(t *testing.T) {
+	type fields struct {
+		base  string
+		build string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "test same point value",
+			fields: fields{
+				base:  "2.1.0",
+				build: "",
+			},
+			want: "2.1",
+		},
+		{
+			name: "test same point value with build",
+			fields: fields{
+				base:  "2.1.0",
+				build: "er1",
+			},
+			want: "2.1",
+		},
+		{
+			name: "test point value with build",
+			fields: fields{
+				base:  "2.1.1",
+				build: "er1",
+			},
+			want: "2.1",
+		},
+		{
+			name: "test point value",
+			fields: fields{
+				base:  "2.1.1",
+				build: "",
+			},
+			want: "2.1",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &RHMIVersion{
+				base:  tt.fields.base,
+				build: tt.fields.build,
+			}
+			if got := v.MajorMinor(); got != tt.want {
+				t.Errorf("RHMIVersion.MajorMinor() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/utils/rhmi_version_test.go
+++ b/pkg/utils/rhmi_version_test.go
@@ -17,7 +17,7 @@ func TestReleaseVersion(t *testing.T) {
 		{
 			description: "Verify release version",
 			version:     "2.0.0",
-			branchName:  "release-v2.0.0",
+			branchName:  "release-2.0",
 			tagName:     "v2.0.0",
 			preRelease:  false,
 			expectError: false,
@@ -25,7 +25,7 @@ func TestReleaseVersion(t *testing.T) {
 		{
 			description: "Verify pre release version",
 			version:     "2.0.0-ER1",
-			branchName:  "release-v2.0.0",
+			branchName:  "release-2.0",
 			tagName:     "v2.0.0-ER1",
 			preRelease:  true,
 			expectError: false,
@@ -67,6 +67,62 @@ func TestReleaseVersion(t *testing.T) {
 				if actual, wanted := v.TagName(), c.tagName; actual != wanted {
 					t.Fatalf("expected %s when build tag name but found %s", wanted, actual)
 				}
+			}
+		})
+	}
+}
+
+func TestRHMIVersion_InitialPointReleaseTag(t *testing.T) {
+	type fields struct {
+		base  string
+		build string
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "test same point value",
+			fields: fields{
+				base:  "2.1.0",
+				build: "",
+			},
+			want: "v2.1.0",
+		},
+		{
+			name: "test same point value with build",
+			fields: fields{
+				base:  "2.1.0",
+				build: "er1",
+			},
+			want: "v2.1.0",
+		},
+		{
+			name: "test point value with build",
+			fields: fields{
+				base:  "2.1.1",
+				build: "er1",
+			},
+			want: "v2.1.0",
+		},
+		{
+			name: "test point value",
+			fields: fields{
+				base:  "2.1.1",
+				build: "",
+			},
+			want: "v2.1.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v := &RHMIVersion{
+				base:  tt.fields.base,
+				build: tt.fields.build,
+			}
+			if got := v.InitialPointReleaseTag(); got != tt.want {
+				t.Errorf("RHMIVersion.InitialPointReleaseTag() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
Adds a new command to setup the integreatly operator and OpenShift CI repos when we are creating a new patch release.

* Creates a new release branch on the operator repo for a given tag e.g. 1.2.1-er1 -> release-v1.2
* Creates config in the openshift release repo to enable PR jobs tests and image mirroring

```
$ ./delorean release openshift-ci-release --help
Update openshift CI Release repo

Usage:
  delorean release openshift-ci-release [flags]

Flags:
      --ci-org-origin string     OpenShift CI Release GitHub org (Origin) (default "integr8ly")
      --ci-org-upstream string   OpenShift CI Release GitHub org (Upstream) (default "openshift")
      --ci-repo string           OpenShift CI Release GitHub repo (default "release")
  -h, --help                     help for openshift-ci-release
```

Example:

```
GITHUB_USER=<my username> GITHUB_TOKEN=<my token> ./delorean release openshift-ci-release -v 1.19.1-er1
```

Verified the PR testing and image mirroring is working as expected.

Jira:

* https://issues.redhat.com/browse/DEL-223  