### PR TITLE
Dockerfile Updates

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -5,13 +5,16 @@ ENV OPERATOR_SDK_VERSION=v0.15.1 \
     OC_VERSION="4.5" \
     GOFLAGS=""
 
-# install oc
 RUN curl -Ls https://mirror.openshift.com/pub/openshift-v4/clients/oc/$OC_VERSION/linux/oc.tar.gz | tar -zx && \
-    mv oc /usr/local/bin
+    mv oc /usr/local/bin && \
+    curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.1.2/yq_linux_amd64 && \
+    chmod +x /usr/local/bin/yq
 
 # install operator-sdk
 RUN curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu && \
     mv operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu /usr/bin/operator-sdk && \
     chmod +x /usr/bin/operator-sdk
 
-COPY build/delorean /usr/bin/delorean
+COPY scripts/delorean /usr/local/bin
+COPY scripts/ocm /usr/local/bin
+COPY build/delorean /usr/local/bin/delorean

--- a/cmd/extractManifests.go
+++ b/cmd/extractManifests.go
@@ -31,7 +31,7 @@ func extractImageManifests(image string, destDir string) error {
 
 	cmdOCManifestExtract := &exec.Cmd{
 		Path:   ocExecutable,
-		Args:   []string{ocExecutable, "image", "extract", image, "--path", "/manifests/:" + destDir, "--confirm"},
+		Args:   []string{ocExecutable, "image", "extract", image, "--path", "/manifests/:" + destDir, "--confirm", "--insecure"},
 		Stdout: os.Stdout,
 		Stderr: os.Stdout,
 	}

--- a/scripts/delorean/mirror-images.sh
+++ b/scripts/delorean/mirror-images.sh
@@ -23,7 +23,7 @@ mirror_images() {
     files=$(find ${MANIFESTS_DIR} -name "image_mirror_mapping")
     for mapping in $files; do
         echo "Running: oc image mirror -f=$mapping --skip-multiple-scopes $ARGS"
-        if ! oc image mirror -f="$mapping" --skip-multiple-scopes $ARGS; then
+        if ! oc image mirror -f="$mapping" --skip-multiple-scopes --insecure $ARGS; then
             echo "ERROR: Failed to mirror images from $mapping"
             failures=$((failures+1))
         fi

--- a/scripts/image/test
+++ b/scripts/image/test
@@ -16,11 +16,16 @@ fi
 alias delorean-docker-run="docker run -u ${UID} --rm -e KUBECONFIG=/kube.config -v \"${HOME}/.kube/config\":/kube.config:z ${TEST_DELOREAN_IMAGE}"
 alias delorean="delorean-docker-run delorean"
 
+#Dependencies
+delorean-docker-run operator-sdk version
+delorean-docker-run oc version || true
+delorean-docker-run yq --version
+
+#Delorean CLI
 delorean --help
 delorean ews --help
 delorean release --help
 
-delorean-docker-run operator-sdk version
-delorean-docker-run oc version
+delorean ews extract-manifests --src-image registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-67
 
 echo "SUCCESS!"


### PR DESCRIPTION
Dockerfile Updates:
* Add delorean scripts into /usr/local/bin
* Add ocm scripts into /usr/local/bin
* Install yq (Required for old scripts)

Add --insecure to oc image commands. We are building this outside the VPN so can't include RH certs, but require the container to pull images from the internal RH registries.