### PR TITLE
Del 254 add process csv images

### DIFF
--- a/cmd/osdAddonRelease.go
+++ b/cmd/osdAddonRelease.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	corev1 "k8s.io/api/core/v1"
 	"path"
 	"time"
 
@@ -440,9 +439,9 @@ func (c *osdAddonReleaseCmd) udpateTheCSVManifest(channel releaseChannel) (strin
 		return "", err
 	}
 
-	_, deployment := findDeploymentByName(csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs, rhmiOperatorDeploymentName)
+	_, deployment := utils.FindDeploymentByName(csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs, rhmiOperatorDeploymentName)
 	if deployment != nil {
-		i, container := findContainerByName(deployment.Spec.Template.Spec.Containers, rhmiOperatorContainerName)
+		i, container := utils.FindContainerByName(deployment.Spec.Template.Spec.Containers, rhmiOperatorContainerName)
 		if container != nil {
 			// Update USE_CLUSTER_STORAGE env var to empty string
 			container.Env = utils.AddOrUpdateEnvVar(container.Env, envVarNameUseClusterStorage, "")
@@ -457,7 +456,7 @@ func (c *osdAddonReleaseCmd) udpateTheCSVManifest(channel releaseChannel) (strin
 	}
 
 	//Set SingleNamespace install mode to true
-	mi, m := findInstallMode(csv.Spec.InstallModes, olmapiv1alpha1.InstallModeTypeSingleNamespace)
+	mi, m := utils.FindInstallMode(csv.Spec.InstallModes, olmapiv1alpha1.InstallModeTypeSingleNamespace)
 	if m != nil {
 		m.Supported = true
 	}
@@ -468,31 +467,4 @@ func (c *osdAddonReleaseCmd) udpateTheCSVManifest(channel releaseChannel) (strin
 		return "", err
 	}
 	return relative, nil
-}
-
-func findDeploymentByName(deployments []olmapiv1alpha1.StrategyDeploymentSpec, name string) (int, *olmapiv1alpha1.StrategyDeploymentSpec) {
-	for i, d := range deployments {
-		if d.Name == name {
-			return i, &d
-		}
-	}
-	return -1, nil
-}
-
-func findContainerByName(containers []corev1.Container, containerName string) (int, *corev1.Container) {
-	for i, c := range containers {
-		if c.Name == containerName {
-			return i, &c
-		}
-	}
-	return -1, nil
-}
-
-func findInstallMode(installModes []olmapiv1alpha1.InstallMode, typeName olmapiv1alpha1.InstallModeType) (int, *olmapiv1alpha1.InstallMode) {
-	for i, m := range installModes {
-		if m.Type == typeName {
-			return i, &m
-		}
-	}
-	return -1, nil
 }

--- a/cmd/osdAddonRelease_test.go
+++ b/cmd/osdAddonRelease_test.go
@@ -277,11 +277,11 @@ func TestOSDAddonRelease(t *testing.T) {
 					if err != nil {
 						t.Fatalf("invalid CSV file content:\n%s", content)
 					}
-					_, deployment := findDeploymentByName(csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs, "rhmi-operator")
+					_, deployment := utils.FindDeploymentByName(csv.Spec.InstallStrategy.StrategySpec.DeploymentSpecs, "rhmi-operator")
 					if deployment == nil {
 						t.Fatalf("can not find rhmi-operator deployment spec in csv file:\n%s", content)
 					}
-					_, container := findContainerByName(deployment.Spec.Template.Spec.Containers, "rhmi-operator")
+					_, container := utils.FindContainerByName(deployment.Spec.Template.Spec.Containers, "rhmi-operator")
 					if container == nil {
 						t.Fatalf("can not find rhmi-operator container spec in csv file:\n%s", content)
 					}
@@ -306,7 +306,7 @@ func TestOSDAddonRelease(t *testing.T) {
 					if !alertEnvVarChecked {
 						t.Fatalf("%s env var should be set to %s in csv file:\n%s", envVarNameAlerEmailAddress, "integreatly-notifications@redhat.com", content)
 					}
-					_, installMode := findInstallMode(csv.Spec.InstallModes, olmapiv1alpha1.InstallModeTypeSingleNamespace)
+					_, installMode := utils.FindInstallMode(csv.Spec.InstallModes, olmapiv1alpha1.InstallModeTypeSingleNamespace)
 					if !installMode.Supported {
 						t.Fatalf("%s value should be true in csv file:\n%s", olmapiv1alpha1.InstallModeTypeSingleNamespace, content)
 					}

--- a/cmd/processCSVImages.go
+++ b/cmd/processCSVImages.go
@@ -1,32 +1,80 @@
 package cmd
 
 import (
-	"fmt"
-
+	"context"
+	"errors"
+	"github.com/integr8ly/delorean/pkg/utils"
 	"github.com/spf13/cobra"
+	"os"
+	"path"
 )
+
+type processCSVImagesCmdOptions struct {
+	manifestDir string
+	isGa        bool
+	extraImages []string
+}
+
+type ProcessCSVImagesCmd func(manifestDir string, isGa bool, extraImages string) error
+
+var processCSVImagesCmdOpts = &processCSVImagesCmdOptions{}
 
 // processCSVImagesCmd represents the processCSVImages command
 var processCSVImagesCmd = &cobra.Command{
 	Use:   "process-csv-images",
 	Short: "Replace internal image registry references and generates an image mirror mapping file.",
 	Long: `Locates the current cluster service version file (csv) for a given product and replaces all occurrences of 
-internal image registries with a deloeran version and generates an image_mirror_mapping file.`,
+internal image registries with a delorean version and generates an image_mirror_mapping file.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("processCSVImages called")
+		err := DoProcessCSV(cmd.Context(), processCSVImagesCmdOpts)
+		if err != nil {
+			handleError(err)
+		}
+
 	},
+}
+
+func DoProcessCSV(ctx context.Context, cmdOpts *processCSVImagesCmdOptions) error {
+	if cmdOpts.manifestDir == "" {
+		return errors.New("manifest-dir not specified")
+	}
+
+	//verify it's a manifest dir.
+	err := utils.VerifyManifestDirs(cmdOpts.manifestDir)
+	if err != nil {
+		handleError(err)
+	}
+
+	if !cmdOpts.isGa {
+		images, err := utils.GetAndUpdateOperandImagesToDeloreanImages(cmdOpts.manifestDir, cmdOpts.extraImages)
+		images, err = utils.UpdateOperatorImagesToDeloreanImages(cmdOpts.manifestDir, images)
+		if err != nil {
+			handleError(err)
+		}
+		if len(images) > 0 {
+			err = utils.CreateImageMirrorMappingFile(cmdOpts.manifestDir, images)
+			if err != nil {
+				handleError(err)
+			}
+		}
+	}
+
+	if cmdOpts.isGa {
+		if utils.FileExists(path.Join(cmdOpts.manifestDir, utils.MappingFile)) {
+			err := os.Remove(path.Join(cmdOpts.manifestDir, utils.MappingFile))
+			if err != nil {
+				handleError(err)
+			}
+		}
+	}
+
+	return nil
 }
 
 func init() {
 	ewsCmd.AddCommand(processCSVImagesCmd)
 
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// processCSVImagesCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// processCSVImagesCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	processCSVImagesCmd.Flags().StringVarP(&processCSVImagesCmdOpts.manifestDir, "manifest-dir", "m", "", "Manifest Directory Location.")
+	processCSVImagesCmd.Flags().BoolVarP(&processCSVImagesCmdOpts.isGa, "isGa", "g", false, "Mark as GA version")
+	processCSVImagesCmd.Flags().StringArrayVarP(&processCSVImagesCmdOpts.extraImages, "extra-images", "e", []string{}, "Extra images to include in container env NAME@IMAGE")
 }

--- a/cmd/processCSVImages.go
+++ b/cmd/processCSVImages.go
@@ -52,7 +52,7 @@ func DoProcessCSV(ctx context.Context, cmdOpts *processCSVImagesCmdOptions) erro
 			handleError(err)
 		}
 		if len(images) > 0 {
-			err = utils.CreateImageMirrorMappingFile(cmdOpts.manifestDir, images)
+			err = utils.WriteToFile(path.Join(cmdOpts.manifestDir, utils.MappingFile), images)
 			if err != nil {
 				handleError(err)
 			}

--- a/cmd/processCSVImages_test.go
+++ b/cmd/processCSVImages_test.go
@@ -1,7 +1,91 @@
 package cmd
 
-import "testing"
+import (
+	"context"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"io/ioutil"
+	"os"
+	"path"
+	"testing"
+)
+
+func mockProcessCSVImages(manifestDir string, isGa bool, extraImages string) error {
+	return nil
+}
+
+const (
+	testCSV = "../pkg/utils/testdata/validManifests/3scale"
+)
 
 func TestProcessCSVImages(t *testing.T) {
-	t.Log("ToDo Add Some Tests!!")
+	// create a temp manifest directory
+	tmpDir, err := ioutil.TempDir(os.TempDir(), "test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	err = utils.CopyDirectory(testCSV, tmpDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	type args struct {
+		ctx        context.Context
+		processCSV ProcessCSVImagesCmd
+		cmdOpts    *processCSVImagesCmdOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr bool
+		verify  func(t *testing.T, err error)
+	}{
+		{
+			name: "Success",
+			args: args{
+				ctx:        context.TODO(),
+				processCSV: mockProcessCSVImages,
+				cmdOpts: &processCSVImagesCmdOptions{
+					manifestDir: tmpDir,
+					isGa:        false,
+					extraImages: []string{},
+				}}, wantErr: false,
+		},
+		{
+			name: "Error on missing manifestDir",
+			args: args{
+				ctx:        context.TODO(),
+				processCSV: mockProcessCSVImages,
+				cmdOpts: &processCSVImagesCmdOptions{
+					manifestDir: "",
+					isGa:        false,
+				}}, wantErr: true,
+		},
+		{
+			name: "Ensure image_mirror_file created",
+			args: args{
+				ctx:        context.TODO(),
+				processCSV: mockProcessCSVImages,
+				cmdOpts: &processCSVImagesCmdOptions{
+					manifestDir: tmpDir,
+					isGa:        false,
+					extraImages: nil,
+				}},
+			verify: func(t *testing.T, err error) {
+				if !utils.FileExists(path.Join(tmpDir, utils.MappingFile)) {
+					t.Fatal("Error: ", err)
+				}
+			}, wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := DoProcessCSV(tt.args.ctx, tt.args.cmdOpts); (err != nil) != tt.wantErr {
+				t.Errorf("buildImageMirrorMappingFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+
 }

--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -1,0 +1,58 @@
+package utils
+
+import (
+	"regexp"
+	"strings"
+)
+
+const (
+	osbsRegistry     = "registry-proxy.engineering.redhat.com/rh-osbs"
+	DeloreanRegistry = "quay.io/integreatly/delorean"
+)
+
+func StripSHAOrTag(in string) string {
+	reImage := regexp.MustCompile(`@.*`)
+	matched := reImage.FindString(in)
+	if matched == "" {
+		s := strings.Split(in, ":")
+		return s[0] + ":" + s[1] + "_" + s[2]
+	}
+	out := reImage.ReplaceAllString(in, "_latest")
+	return out
+}
+
+func BuildDeloreanImage(image string) string {
+	s := strings.Split(image, "/")
+	if s[0] == "quay.io" && s[1] == "integreatly" {
+		i := strings.Split(image, ":")
+		image = DeloreanRegistry + i[1]
+		return image
+	}
+
+	//we need to treat the amq broker image differently
+	amq := strings.Split(image, ":")
+	imagename := strings.Split(amq[0], "/")
+	if imagename[2] == "amq-broker" {
+		majorversion := strings.Split(amq[1], ".")
+		majmin := strings.Split(majorversion[1], "-")
+		image = DeloreanRegistry + ":" + imagename[2] + "-" + majorversion[0] + "-" + imagename[2] + "-" + majorversion[0] + majmin[0] + "-openshift" + ":" + majorversion[0] + "." + majmin[0]
+		return image
+	}
+
+	image = DeloreanRegistry + ":" + s[1] + "-" + s[2]
+	return image
+}
+
+func BuildOSBSImage(image string) string {
+	s := strings.Split(image, "/")
+
+	//we need to treat the crw operator image differently
+	crw := strings.Split(s[2], "@")
+	if crw[0] == "crw-2-rhel8-operator" {
+		image = osbsRegistry + "/" + s[1] + "-" + "operator" + "@" + crw[1]
+		return image
+	}
+
+	image = osbsRegistry + "/" + s[1] + "-" + s[2]
+	return image
+}

--- a/pkg/utils/images_test.go
+++ b/pkg/utils/images_test.go
@@ -1,0 +1,1 @@
+package utils

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -2,12 +2,18 @@ package utils
 
 import (
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"os"
+	"path"
 
 	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/ghodss/yaml"
+)
+
+const (
+	MappingFile = "image_mirror_mapping"
 )
 
 // PopulateObjectFromYAML will read the content from the given yaml file and use it to unmarshal the given object
@@ -121,4 +127,34 @@ func deleteKeyFromUnstructured(u map[string]interface{}, key string) {
 			}
 		}
 	}
+}
+
+func FileExists(filename string) bool {
+	info, err := os.Stat(filename)
+	if os.IsNotExist(err) {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func CreateImageMirrorMappingFile(manifestDir string, images []string) error {
+
+	mirrorFilePath := path.Join(manifestDir, MappingFile)
+	f, err := os.Create(mirrorFilePath)
+	if err != nil {
+		return err
+	}
+
+	for _, i := range images {
+		_, err = fmt.Fprintln(f, i)
+		if err != nil {
+			return err
+		}
+	}
+	err = f.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -4,10 +4,8 @@ import (
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"os"
-	"path"
-
 	"k8s.io/apimachinery/pkg/runtime"
+	"os"
 
 	"github.com/ghodss/yaml"
 )
@@ -137,15 +135,13 @@ func FileExists(filename string) bool {
 	return !info.IsDir()
 }
 
-func CreateImageMirrorMappingFile(manifestDir string, images []string) error {
-
-	mirrorFilePath := path.Join(manifestDir, MappingFile)
-	f, err := os.Create(mirrorFilePath)
+func WriteToFile(writePath string, content []string) error {
+	f, err := os.Create(writePath)
 	if err != nil {
 		return err
 	}
 
-	for _, i := range images {
+	for _, i := range content {
 		_, err = fmt.Fprintln(f, i)
 		if err != nil {
 			return err


### PR DESCRIPTION
Add process-csv-images command.

To Verify
- Checkout this branch
- `Make build/cli`
- `./delorean ews process-csv-images --manifest-dir ../integreatly-operator/manifests/integreatly-<product>/`
- For fuse use the command `/delorean ews process-csv-images --manifest-dir ../integreatly-operator/manifests/integreatly-fuse-online/ -e DV_IMAGE=registry.redhat.io/fuse7-tech-preview/fuse-dv-rhel7:1.6 -e OAUTH_IMAGE=registry.redhat.io/openshift4/ose-oauth-proxy:4.2 -e UI_IMAGE=registry.redhat.io/fuse7/fuse-ignite-ui:1.6 -e S2I_IMAGE=registry.redhat.io/fuse7/fuse-ignite-s2i:1.6 -e PROMETHEUS_IMAGE=registry.redhat.io/openshift3/prometheus:v3.9 -e UPGRADE_IMAGE=registry.redhat.io/fuse7/fuse-ignite-upgrade:1.6 -e META_IMAGE=registry.redhat.io/fuse7/fuse-ignite-meta:1.6 -e PSQL_EXPORTER_IMAGE=registry.redhat.io/fuse7-tech-preview/fuse-postgres-exporter:1.6 -e SERVER_IMAGE=registry.redhat.io/fuse7/fuse-ignite-server:1.6` to include the extra image vars the operator needs
- Verify the csv images have been changed to point to `quay.io/integreatly/delorean...` and that the image_mirror_mapping exists and is populated

TODO

- Image entries can be duplicated, should dedupe before writing to the image_mirror_mapping file