### PR TITLE
Add WriteK8sObjectToYAML util

### DIFF
--- a/cmd/osdAddonRelease.go
+++ b/cmd/osdAddonRelease.go
@@ -421,7 +421,7 @@ func (c *osdAddonReleaseCmd) udpateThePackageManifest(channel releaseChannel) (s
 	// Set channels[0].currentCSV value
 	p.Channels[0].CurrentCSVName = fmt.Sprintf("integreatly-operator.v%s", c.version.Base())
 
-	err = utils.WriteObjectToYAML(p, manifest)
+	err = utils.WriteK8sObjectToYAML(p, manifest)
 	if err != nil {
 		return "", err
 	}
@@ -463,7 +463,7 @@ func (c *osdAddonReleaseCmd) udpateTheCSVManifest(channel releaseChannel) (strin
 	}
 	csv.Spec.InstallModes[mi] = *m
 
-	err = utils.WriteObjectToYAML(csv, csvFile)
+	err = utils.WriteK8sObjectToYAML(csv, csvFile)
 	if err != nil {
 		return "", err
 	}

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	k8s.io/api v0.18.0
+	k8s.io/apimachinery v0.18.0
 	rsc.io/letsencrypt v0.0.3 // indirect
 )
 

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"io/ioutil"
+	"k8s.io/apimachinery/pkg/runtime"
 	"os"
 
 	"github.com/ghodss/yaml"
@@ -34,7 +35,27 @@ func WriteObjectToYAML(obj interface{}, yamlFile string) error {
 	if err != nil {
 		return err
 	}
+	return writeToYAML(bytes, yamlFile)
+}
 
+func WriteK8sObjectToYAML(obj interface{}, yamlFile string) error {
+	u, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		return err
+	}
+	deleteKeys := []string{"status", "creationTimestamp"}
+	for _, dk := range deleteKeys {
+		deleteKeyFromUnstructured(u, dk)
+	}
+
+	bytes, err := yaml.Marshal(u)
+	if err != nil {
+		return err
+	}
+	return writeToYAML(bytes, yamlFile)
+}
+
+func writeToYAML(bytes []byte, yamlFile string) error {
 	// truncate the existing file
 	write, err := os.Create(yamlFile)
 	if err != nil {
@@ -51,4 +72,25 @@ func WriteObjectToYAML(obj interface{}, yamlFile string) error {
 		return err
 	}
 	return nil
+}
+
+//https://github.com/operator-framework/operator-sdk/blob/master/internal/util/k8sutil/object.go
+func deleteKeyFromUnstructured(u map[string]interface{}, key string) {
+	if _, ok := u[key]; ok {
+		delete(u, key)
+		return
+	}
+
+	for _, v := range u {
+		switch t := v.(type) {
+		case map[string]interface{}:
+			deleteKeyFromUnstructured(t, key)
+		case []interface{}:
+			for _, ti := range t {
+				if m, ok := ti.(map[string]interface{}); ok {
+					deleteKeyFromUnstructured(m, key)
+				}
+			}
+		}
+	}
 }

--- a/pkg/utils/io_test.go
+++ b/pkg/utils/io_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path"
@@ -12,6 +13,12 @@ type sampleYAML struct {
 	Value  int            `yaml:"value,omitempty"`
 	Array  []int          `yaml:"array,omitempty"`
 	Object map[string]int `yaml:"object,omitempty"`
+}
+
+type sampleK8sYAML struct {
+	Name              string `yaml:"name,omitempty"`
+	Status            string `yaml:"status"`
+	CreationTimestamp string `yaml:"creationTimestamp"`
 }
 
 func TestPopulateObjectFromYAML(t *testing.T) {
@@ -66,6 +73,33 @@ Object:
   key: 1
 Value: 1
 `
+	if content != expected {
+		t.Errorf("expected output is not valid. Expected:\n%s\n Actual:\n%s\n", expected, content)
+	}
+}
+
+func TestWriteK8sObjectToYAML(t *testing.T) {
+	tmp, err := ioutil.TempDir(os.TempDir(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+	obj := &sampleK8sYAML{
+		Name:              "test",
+		Status:            "test",
+		CreationTimestamp: "test",
+	}
+	dest := path.Join(tmp, "out.yaml")
+	err = WriteK8sObjectToYAML(obj, dest)
+	if err != nil {
+		t.Errorf("failed to write yaml file: %v", err)
+	}
+	content := readFile(t, dest)
+	expected := "name: test\n"
+
+	fmt.Println(content)
+	fmt.Println(expected)
+
 	if content != expected {
 		t.Errorf("expected output is not valid. Expected:\n%s\n Actual:\n%s\n", expected, content)
 	}


### PR DESCRIPTION
Add WriteK8sObjectToYAML util, removes k8s runtime managed fileds from object before writing to file.

When writing the csv extra runtime fields were being added to the file.