### PR TITLE
Add cmd to retrieve the current-csv from the manifests directory

### DIFF
--- a/cmd/currentCSV.go
+++ b/cmd/currentCSV.go
@@ -1,9 +1,7 @@
 package cmd
 
 import (
-	"encoding/json"
 	"fmt"
-	"os"
 
 	"github.com/integr8ly/delorean/pkg/utils"
 	"github.com/spf13/cobra"
@@ -28,26 +26,7 @@ func init() {
 			}
 
 			fmt.Printf("Write current CSV %s to %s\n", file, flags.output)
-			bytes, err := json.Marshal(csv)
-			if err != nil {
-				handleError(err)
-			}
-
-			// truncate the existing file
-			write, err := os.Create(flags.output)
-			if err != nil {
-				handleError(err)
-			}
-
-			_, err = write.Write(bytes)
-			if err != nil {
-				handleError(err)
-			}
-
-			err = write.Close()
-			if err != nil {
-				handleError(err)
-			}
+			utils.WriteObjectToJSON(csv, flags.output)
 		},
 	}
 

--- a/cmd/currentCSV.go
+++ b/cmd/currentCSV.go
@@ -1,0 +1,61 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/integr8ly/delorean/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type currentCSVFlags struct {
+	directory string
+	output    string
+}
+
+func init() {
+
+	flags := &currentCSVFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "current-csv",
+		Short: "Retrieve the current CSV from the manifests directory and write it in JSON format to the output file",
+		Run: func(cmd *cobra.Command, args []string) {
+			csv, file, err := utils.GetCurrentCSV(flags.directory)
+			if err != nil {
+				handleError(err)
+			}
+
+			fmt.Printf("Write current CSV %s to %s\n", file, flags.output)
+			bytes, err := json.Marshal(csv)
+			if err != nil {
+				handleError(err)
+			}
+
+			// truncate the existing file
+			write, err := os.Create(flags.output)
+			if err != nil {
+				handleError(err)
+			}
+
+			_, err = write.Write(bytes)
+			if err != nil {
+				handleError(err)
+			}
+
+			err = write.Close()
+			if err != nil {
+				handleError(err)
+			}
+		},
+	}
+
+	ewsCmd.AddCommand(cmd)
+
+	cmd.Flags().StringVarP(&flags.directory, "directory", "d", "", "Path to the directory containing the manifests from which to extract the current CSV")
+	cmd.MarkFlagRequired("directory")
+
+	cmd.Flags().StringVarP(&flags.output, "output", "o", "", "File path in which to write the current CSV in JSON")
+	cmd.MarkFlagRequired("output")
+}

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -3,8 +3,9 @@ package utils
 import (
 	"encoding/json"
 	"io/ioutil"
-	"k8s.io/apimachinery/pkg/runtime"
 	"os"
+
+	"k8s.io/apimachinery/pkg/runtime"
 
 	"github.com/ghodss/yaml"
 )
@@ -100,7 +101,7 @@ func WriteObjectToJSON(obj interface{}, jsonFile string) error {
 
 	return nil
 }
-  
+
 //https://github.com/operator-framework/operator-sdk/blob/master/internal/util/k8sutil/object.go
 func deleteKeyFromUnstructured(u map[string]interface{}, key string) {
 	if _, ok := u[key]; ok {

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"encoding/json"
 	"io/ioutil"
 	"os"
 
@@ -50,5 +51,31 @@ func WriteObjectToYAML(obj interface{}, yamlFile string) error {
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// WriteObjectToJSON will marshal the given object and write to the given json file
+func WriteObjectToJSON(obj interface{}, jsonFile string) error {
+	bytes, err := json.Marshal(obj)
+	if err != nil {
+		return err
+	}
+
+	// truncate the existing file
+	write, err := os.Create(jsonFile)
+	if err != nil {
+		return err
+	}
+
+	_, err = write.Write(bytes)
+	if err != nil {
+		return err
+	}
+
+	err = write.Close()
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/pkg/utils/io_test.go
+++ b/pkg/utils/io_test.go
@@ -14,6 +14,13 @@ type sampleYAML struct {
 	Object map[string]int `yaml:"object,omitempty"`
 }
 
+type sampleJSON struct {
+	Name   string         `json:"name,omitempty"`
+	Value  int            `json:"value,omitempty"`
+	Array  []int          `json:"array,omitempty"`
+	Object map[string]int `json:"object,omitempty"`
+}
+
 func TestPopulateObjectFromYAML(t *testing.T) {
 	content := `
 name: test
@@ -66,6 +73,30 @@ Object:
   key: 1
 Value: 1
 `
+	if content != expected {
+		t.Errorf("expected output is not valid. Expected:\n%s\n Actual:\n%s\n", expected, content)
+	}
+}
+
+func TestWriteObjectToJSON(t *testing.T) {
+	tmp, err := ioutil.TempDir(os.TempDir(), "test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmp)
+	obj := &sampleJSON{
+		Name:   "test",
+		Value:  1,
+		Array:  []int{1, 2},
+		Object: map[string]int{"key": 1},
+	}
+	dest := path.Join(tmp, "out.json")
+	err = WriteObjectToJSON(obj, dest)
+	if err != nil {
+		t.Errorf("failed to write json file: %v", err)
+	}
+	content := readFile(t, dest)
+	expected := `{"name":"test","value":1,"array":[1,2],"object":{"key":1}}`
 	if content != expected {
 		t.Errorf("expected output is not valid. Expected:\n%s\n Actual:\n%s\n", expected, content)
 	}


### PR DESCRIPTION
**What**

The cmd will retrieve the current CSV from the manifests directory containing multiple CSVs

**Verify**

1. Download and extract the manifests directory

```
export SRC_IMAGE='registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata@sha256:8355860dbc1052884138612fe1b12a149ceee58440831c041eb3fd45bb38a52e'
mkdir /tmp/mydir
./delorean ews extract-manifests --src-image ${SRC_IMAGE} --extract-dir /tmp/mydir
```
 
2. Retrieve the current CSV from `/tmp/mydir`

```
delorean ews current-csv --directory /tmp/mydir --output /tm/tmpcurrentcsv.json
```
