### PR TITLE
feat: custom CIDR ranges, private cluster option

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -74,16 +74,22 @@ get_latest_generated_access_key_id() {
 
 create_cluster_configuration_file() {
     local timestamp
+    local listening="external"
 
     : "${OCM_CLUSTER_LIFESPAN:=4}"
     : "${OCM_CLUSTER_NAME:=rhmi-$(date +"%y%m%d-%H%M")}"
     : "${OCM_CLUSTER_REGION:=eu-west-1}"
     : "${BYOC:=false}"
     : "${OPENSHIFT_VERSION:=}"
+    : "${PRIVATE:=false}"
 
     timestamp=$(get_expiration_timestamp "${OCM_CLUSTER_LIFESPAN}")
 
-    jq ".expiration_timestamp = \"${timestamp}\" | .name = \"${OCM_CLUSTER_NAME}\" | .region.id = \"${OCM_CLUSTER_REGION}\"" \
+    if [ "${PRIVATE}" = true ]; then
+        listening="internal"
+    fi
+
+    jq ".expiration_timestamp = \"${timestamp}\" | .name = \"${OCM_CLUSTER_NAME}\" | .region.id = \"${OCM_CLUSTER_REGION}\" | .api.listening = \"${listening}\"" \
         < "${CLUSTER_TEMPLATE_FILE}" \
         > "${CLUSTER_CONFIGURATION_FILE}"
 	
@@ -314,6 +320,7 @@ Optional exported variables:
 - OCM_CLUSTER_REGION                e.g. eu-west-1
 - BYOC                              true/false (default: false)
 - OPENSHIFT_VERSION                 to get OpenShift versions, run: ocm cluster versions
+- PRIVATE                           Cluster's API and router will be private
 ==========================================================================================
 create_cluster                    - spin up OSD cluster
 ==========================================================================================

--- a/templates/ocm/OWNERS
+++ b/templates/ocm/OWNERS
@@ -1,0 +1,5 @@
+# See the OWNERS docs: https://git.k8s.io/community/contributors/guide/owners.md
+
+approvers:
+- psturc
+

--- a/templates/ocm/cluster-template.json
+++ b/templates/ocm/cluster-template.json
@@ -3,6 +3,12 @@
     "managed": true,
     "multi_az": false,
     "name": "my_cluster_name",
+    "network": {
+      "machine_cidr": "10.11.128.0/23",
+      "service_cidr": "10.11.0.0/18",
+      "pod_cidr": "10.11.64.0/18",
+      "host_prefix": 23
+    },
     "nodes" : {
       "compute" : 4,
       "compute_machine_type" : {"id" : "m5.xlarge" }


### PR DESCRIPTION
### Motivation
https://issues.redhat.com/browse/INTLY-7661

### What was changed
* added [custom OSD network configuration](https://github.com/integr8ly/delorean/compare/master...psturc:ocm-networking-updates?expand=1#diff-30c6bfb85a01f21bab414346c984d3e3R6-R11) (as suggested [here](https://issues.redhat.com/browse/INTLY-7658?focusedCommentId=14088967&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-14088967))
* added option to install private cluster

### How to verify
1. Clone this branch
2. Run `make ocm/cluster.json`
> Printed out cluster configuration should contain the network config [from the template](https://github.com/integr8ly/delorean/compare/master...psturc:ocm-networking-updates?expand=1#diff-30c6bfb85a01f21bab414346c984d3e3R6-R11)
3. Run `make ocm/cluster.json PRIVATE=true`
> You should see `"api": {"listening": "internal"}` in the output (meaning that the cluster with this field will be configured as private)