### PR TITLE
Update csv file discovery

### DIFF
--- a/cmd/extractManifests.go
+++ b/cmd/extractManifests.go
@@ -60,6 +60,11 @@ func copyLatestManifest(srcPkgDir, destPkgDir string) (string, string, error) {
 		return "", "", err
 	}
 
+	err = utils.ProcessCurrentCSV(destPkgDir, nil)
+	if err != nil {
+		return "", "", err
+	}
+
 	return srcBundleDir, destBundleDir, nil
 }
 

--- a/cmd/extractManifests.go
+++ b/cmd/extractManifests.go
@@ -48,7 +48,7 @@ func copyLatestManifest(srcPkgDir, destPkgDir string) (string, string, error) {
 	}
 
 	srcBundleDir := filepath.Dir(csvFile)
-	destBundleDir := filepath.Join(destPkgDir, filepath.Base(srcBundleDir))
+	destBundleDir := filepath.Join(destPkgDir, csv.Spec.Version.String())
 
 	err = utils.CopyDirectory(srcBundleDir, destBundleDir)
 	if err != nil {

--- a/pkg/utils/csv.go
+++ b/pkg/utils/csv.go
@@ -163,3 +163,25 @@ func UpdatePackageManifest(packageDir, currentCSVName string) (*registry.Package
 
 	return pkgManifest, nil
 }
+
+func ProcessCurrentCSV(packageDir string, processFunc process) error {
+	csv, csvfile, err := GetCurrentCSV(packageDir)
+	if err != nil {
+		return err
+	}
+
+	if processFunc != nil {
+		err = processFunc(csv)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = WriteK8sObjectToYAML(csv, csvfile)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+type process func(*olmapiv1alpha1.ClusterServiceVersion) error

--- a/pkg/utils/csv.go
+++ b/pkg/utils/csv.go
@@ -40,7 +40,7 @@ func ReadCSVFromBundleDirectory(bundleDir string) (*olmapiv1alpha1.ClusterServic
 	}
 
 	for _, file := range files {
-		if strings.Contains(file, ".clusterserviceversion.yaml") {
+		if strings.Contains(file, ".clusterserviceversion.yaml") || strings.Contains(file, ".csv.yaml") {
 			bundleFilepath := path.Join(bundleDir, file)
 			var csv *olmapiv1alpha1.ClusterServiceVersion
 			err := PopulateObjectFromYAML(bundleFilepath, &csv)


### PR DESCRIPTION
* Allow different naming of csv file (CRW uses csv.yaml)
* Use csv version to determine dest dir (crw is prepending v to the directory)
*  Process current csv during copy (Ensures that all manifests added to a manifest directory are always in the processed order)


