### PR TITLE
Ensure image mappings are unique

### DIFF
--- a/cmd/processCSVImages.go
+++ b/cmd/processCSVImages.go
@@ -45,7 +45,14 @@ func DoProcessCSV(ctx context.Context, cmdOpts *processCSVImagesCmdOptions) erro
 		handleError(err)
 	}
 
-	if !cmdOpts.isGa {
+	if cmdOpts.isGa {
+		if utils.FileExists(path.Join(cmdOpts.manifestDir, utils.MappingFile)) {
+			err := os.Remove(path.Join(cmdOpts.manifestDir, utils.MappingFile))
+			if err != nil {
+				handleError(err)
+			}
+		}
+	} else {
 		images, err := utils.GetAndUpdateOperandImagesToDeloreanImages(cmdOpts.manifestDir, cmdOpts.extraImages)
 		images, err = utils.UpdateOperatorImagesToDeloreanImages(cmdOpts.manifestDir, images)
 		if err != nil {
@@ -53,15 +60,6 @@ func DoProcessCSV(ctx context.Context, cmdOpts *processCSVImagesCmdOptions) erro
 		}
 		if len(images) > 0 {
 			err = utils.WriteToFile(path.Join(cmdOpts.manifestDir, utils.MappingFile), images)
-			if err != nil {
-				handleError(err)
-			}
-		}
-	}
-
-	if cmdOpts.isGa {
-		if utils.FileExists(path.Join(cmdOpts.manifestDir, utils.MappingFile)) {
-			err := os.Remove(path.Join(cmdOpts.manifestDir, utils.MappingFile))
 			if err != nil {
 				handleError(err)
 			}

--- a/cmd/processCSVImages.go
+++ b/cmd/processCSVImages.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"fmt"
 	"github.com/integr8ly/delorean/pkg/utils"
 	"github.com/spf13/cobra"
 	"os"
@@ -59,7 +60,13 @@ func DoProcessCSV(ctx context.Context, cmdOpts *processCSVImagesCmdOptions) erro
 			handleError(err)
 		}
 		if len(images) > 0 {
-			err = utils.WriteToFile(path.Join(cmdOpts.manifestDir, utils.MappingFile), images)
+
+			mappingLines := []string{}
+			for src, dest := range images {
+				mappingLines = append(mappingLines, fmt.Sprintf("%s %s", src, dest))
+			}
+
+			err = utils.WriteToFile(path.Join(cmdOpts.manifestDir, utils.MappingFile), mappingLines)
 			if err != nil {
 				handleError(err)
 			}

--- a/cmd/processCSVImages_test.go
+++ b/cmd/processCSVImages_test.go
@@ -101,16 +101,14 @@ func TestProcessCSVImages(t *testing.T) {
 				}
 				defer file.Close()
 
-				uniqueLines := map[string]string{}
 				var lines []string
 				scanner := bufio.NewScanner(file)
 				for scanner.Scan() {
 					lines = append(lines, scanner.Text())
-					uniqueLines[scanner.Text()] = scanner.Text()
 				}
 
 				numMappings := len(lines)
-				numExpectedMappings := len(uniqueLines)
+				numExpectedMappings := 9 // 3scale2 manifest contains 9 unique images, but 11 references overall
 				if numMappings != numExpectedMappings {
 					t.Errorf("expected %v image miror mappings, found %v", numExpectedMappings, numMappings)
 				}

--- a/cmd/processCSVImages_test.go
+++ b/cmd/processCSVImages_test.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"github.com/integr8ly/delorean/pkg/utils"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -13,22 +13,7 @@ func mockProcessCSVImages(manifestDir string, isGa bool, extraImages string) err
 	return nil
 }
 
-const (
-	testCSV = "../pkg/utils/testdata/validManifests/3scale"
-)
-
 func TestProcessCSVImages(t *testing.T) {
-	// create a temp manifest directory
-	tmpDir, err := ioutil.TempDir(os.TempDir(), "test-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	err = utils.CopyDirectory(testCSV, tmpDir)
-	if err != nil {
-		t.Fatal(err)
-	}
 
 	type args struct {
 		ctx        context.Context
@@ -36,18 +21,19 @@ func TestProcessCSVImages(t *testing.T) {
 		cmdOpts    *processCSVImagesCmdOptions
 	}
 	tests := []struct {
-		name    string
-		args    args
-		wantErr bool
-		verify  func(t *testing.T, err error)
+		name                 string
+		tstCreateManifestDir string
+		args                 args
+		wantErr              bool
+		verify               func(t *testing.T, manifestDir string) error
 	}{
 		{
-			name: "Success",
+			name:                 "Success",
+			tstCreateManifestDir: "../pkg/utils/testdata/validManifests/3scale",
 			args: args{
 				ctx:        context.TODO(),
 				processCSV: mockProcessCSVImages,
 				cmdOpts: &processCSVImagesCmdOptions{
-					manifestDir: tmpDir,
 					isGa:        false,
 					extraImages: []string{},
 				}}, wantErr: false,
@@ -63,27 +49,94 @@ func TestProcessCSVImages(t *testing.T) {
 				}}, wantErr: true,
 		},
 		{
-			name: "Ensure image_mirror_file created",
+			name:                 "Ensure image_mirror_file created",
+			tstCreateManifestDir: "../pkg/utils/testdata/validManifests/3scale",
 			args: args{
 				ctx:        context.TODO(),
 				processCSV: mockProcessCSVImages,
 				cmdOpts: &processCSVImagesCmdOptions{
-					manifestDir: tmpDir,
 					isGa:        false,
 					extraImages: nil,
 				}},
-			verify: func(t *testing.T, err error) {
-				if !utils.FileExists(path.Join(tmpDir, utils.MappingFile)) {
-					t.Fatal("Error: ", err)
+			verify: func(t *testing.T, manifestDir string) error {
+				mappingFile := path.Join(manifestDir, utils.MappingFile)
+				if !utils.FileExists(mappingFile) {
+					t.Fatal("Error: mapping file does not exist ", mappingFile)
 				}
+				return nil
+			}, wantErr: false,
+		},
+		{
+			name:                 "Ensure image_mirror_file not created",
+			tstCreateManifestDir: "../pkg/utils/testdata/validManifests/3scale",
+			args: args{
+				ctx:        context.TODO(),
+				processCSV: mockProcessCSVImages,
+				cmdOpts: &processCSVImagesCmdOptions{
+					isGa: true,
+				}},
+			verify: func(t *testing.T, manifestDir string) error {
+				mappingFile := path.Join(manifestDir, utils.MappingFile)
+				if utils.FileExists(mappingFile) {
+					t.Fatal("Error: mapping file exists ", mappingFile)
+				}
+				return nil
+			}, wantErr: false,
+		},
+		{
+			name:                 "Ensure image_mirror_file entries are unique",
+			tstCreateManifestDir: "../pkg/utils/testdata/validManifests/3scale2",
+			args: args{
+				ctx:        context.TODO(),
+				processCSV: mockProcessCSVImages,
+				cmdOpts: &processCSVImagesCmdOptions{
+					isGa: false,
+				}},
+			verify: func(t *testing.T, manifestDir string) error {
+				mappingFile := path.Join(manifestDir, utils.MappingFile)
+
+				file, err := os.Open(mappingFile)
+				if err != nil {
+					return err
+				}
+				defer file.Close()
+
+				uniqueLines := map[string]string{}
+				var lines []string
+				scanner := bufio.NewScanner(file)
+				for scanner.Scan() {
+					lines = append(lines, scanner.Text())
+					uniqueLines[scanner.Text()] = scanner.Text()
+				}
+
+				numMappings := len(lines)
+				numExpectedMappings := len(uniqueLines)
+				if numMappings != numExpectedMappings {
+					t.Errorf("expected %v image miror mappings, found %v", numExpectedMappings, numMappings)
+				}
+
+				return nil
 			}, wantErr: false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+
+			if tt.tstCreateManifestDir != "" {
+				tstDir := createTempTesManifesttDir(t, tt.tstCreateManifestDir)
+				defer os.RemoveAll(tstDir)
+				tt.args.cmdOpts.manifestDir = tstDir
+			}
+
 			if err := DoProcessCSV(tt.args.ctx, tt.args.cmdOpts); (err != nil) != tt.wantErr {
 				t.Errorf("buildImageMirrorMappingFile() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.verify != nil {
+				if err := tt.verify(t, tt.args.cmdOpts.manifestDir); err != nil {
+					t.Fatalf("verification failed due to error: %v", err)
+				}
 			}
 		})
 	}


### PR DESCRIPTION
Fixes an issue where image mapping files were sometimes getting generated with duplicate entries causing the image mirroring to fail.

Latest 3scale manifest is an example of one with more than one reference to an image in it's CSV file:

```
./delorean ews extract-manifests --src-image registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-82
```