### PR TITLE
Add make to Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -7,7 +7,10 @@ ENV OPERATOR_SDK_VERSION=v0.15.1 \
 
 COPY resources/rhit-root-ca.crt /etc/pki/ca-trust/source/anchors/
 
-RUN update-ca-trust extract && \
+RUN set -o pipefail && \
+    INSTALL_PKGS="make" && \
+    yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
+    update-ca-trust extract && \
     curl -Ls https://mirror.openshift.com/pub/openshift-v4/clients/oc/$OC_VERSION/linux/oc.tar.gz | tar -zx && \
     mv oc /usr/local/bin && \
     curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.1.2/yq_linux_amd64 && \

--- a/scripts/image/test
+++ b/scripts/image/test
@@ -20,6 +20,7 @@ alias delorean="delorean-docker-run delorean"
 delorean-docker-run operator-sdk version
 delorean-docker-run oc version || true
 delorean-docker-run yq --version
+delorean-docker-run make --version
 
 #Delorean CLI
 delorean --help


### PR DESCRIPTION
Required so we can run make targets from the intly operator repo in pipelines.

/cc @StanleyKaleta @wei-lee 

```
$ make image/test CONTAINER_ENGINE=podman
....
+ podman run -u 1000 --rm -e KUBECONFIG=/kube.config -v /home/mnairn/.kube/config:/kube.config:z quay.io/integreatly/delorean-cli:latest make --version                                                            
GNU Make 3.82    
....
```