### PR TITLE
INTLY-6618 Add cmd to create the Polarion release

### DIFF
--- a/cmd/polarionRelease.go
+++ b/cmd/polarionRelease.go
@@ -1,0 +1,214 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/integr8ly/delorean/pkg/polarion"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+const (
+	polarionUsernameKey = "polarion_username"
+	polarionPasswordKey = "polarion_password"
+
+	polarionProjectID = "RedHatManagedIntegration"
+
+	polarionURL        = "https://polarion.engineering.redhat.com/polarion/ws/services"
+	polarionStagingURL = "https://polarion.stage.engineering.redhat.com/polarion/ws/services"
+)
+
+type polarionReleaseFlags struct {
+	version string
+	stage   bool
+	debug   bool
+}
+
+type polarionReleaseCmd struct {
+	version  *utils.RHMIVersion
+	polarion polarion.PolarionSessionService
+}
+
+func newPolarionReleaseCmd(f *polarionReleaseFlags) (*polarionReleaseCmd, error) {
+
+	version, err := utils.NewRHMIVersion(f.version)
+	if err != nil {
+		return nil, err
+	}
+
+	polarionUsername, err := requireValue(polarionUsernameKey)
+	if err != nil {
+		return nil, err
+	}
+
+	polarionPassword, err := requireValue(polarionPasswordKey)
+	if err != nil {
+		return nil, err
+	}
+
+	var url string
+	if f.stage {
+		url = polarionStagingURL
+	} else {
+		url = polarionURL
+	}
+
+	polarion, err := polarion.NewSession(polarionUsername, polarionPassword, url, f.debug)
+	if err != nil {
+		return nil, err
+	}
+
+	return &polarionReleaseCmd{
+		version:  version,
+		polarion: polarion,
+	}, nil
+}
+
+func init() {
+	f := &polarionReleaseFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "polarion-release",
+		Short: "Prepare the release version in Polarion",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			c, err := newPolarionReleaseCmd(f)
+			if err != nil {
+				handleError(err)
+			}
+
+			err = c.run()
+			if err != nil {
+				handleError(err)
+			}
+		},
+	}
+
+	reportCmd.AddCommand(cmd)
+
+	cmd.Flags().StringVar(&f.version, "version", "", "The RHMI version to create in Polarion (ex \"2.0.0\", \"2.0.0-er4\")")
+	cmd.MarkFlagRequired("version")
+
+	cmd.Flags().BoolVar(&f.stage, "stage", false, "Create the release in the Polarion staging environment")
+	cmd.Flags().BoolVar(&f.debug, "debug", false, "Print the Polarion API request and response")
+
+	cmd.Flags().String("polarion-username", "", "Polarion username")
+	viper.BindPFlag(polarionUsernameKey, cmd.Flags().Lookup("polarion-username"))
+
+	cmd.Flags().String("polarion-password", "", "Polarion password")
+	viper.BindPFlag(polarionPasswordKey, cmd.Flags().Lookup("polarion-password"))
+}
+
+func (c *polarionReleaseCmd) run() error {
+
+	if !c.version.IsPreRelease() {
+		fmt.Println("skip non pre-release", c.version.String())
+		return nil
+	}
+
+	err := c.creteRelease()
+	if err != nil {
+		return fmt.Errorf("failed to create the release for %s with error: %s", c.version, err)
+	}
+
+	err = c.creteMilestone()
+	if err != nil {
+		return fmt.Errorf("failed to create the milestone for %s with error: %s", c.version, err)
+	}
+
+	err = c.createTestRunTemplate()
+	if err != nil {
+		return fmt.Errorf("failed to create the test run template for %s with error: %s", c.version, err)
+	}
+
+	return nil
+}
+
+func (c *polarionReleaseCmd) creteRelease() error {
+
+	id := c.version.PolarionReleaseId()
+
+	plan, err := c.polarion.GetPlanByID(polarionProjectID, id)
+	if err != nil {
+		return err
+	}
+
+	if plan.ID != "" {
+		fmt.Printf("the release '%s' already exists\n", plan.ID)
+		return nil
+	}
+
+	err = c.polarion.CreatePlan(
+		polarionProjectID,
+		c.version.MajorMinorPatch(),
+		id,
+		"",
+		"release",
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("the release '%s' has been created\n", id)
+	return nil
+}
+
+func (c *polarionReleaseCmd) creteMilestone() error {
+
+	id := c.version.PolarionMilestoneId()
+
+	plan, err := c.polarion.GetPlanByID(polarionProjectID, id)
+	if err != nil {
+		return err
+	}
+
+	if plan.ID != "" {
+		fmt.Printf("the milestone '%s' already exists\n", plan.ID)
+		return nil
+	}
+
+	err = c.polarion.CreatePlan(
+		polarionProjectID,
+		c.version.String(),
+		id,
+		c.version.PolarionReleaseId(),
+		"Beta",
+	)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("the milestone '%s' has been created\n", id)
+	return nil
+}
+
+func (c *polarionReleaseCmd) createTestRunTemplate() error {
+
+	id := c.version.PolarionMilestoneId()
+
+	template, err := c.polarion.GetTestRunByID(polarionProjectID, id)
+	if err != nil {
+		return err
+	}
+
+	if template.ID != "" {
+		fmt.Printf("the test run template '%s' already exists\n", template.ID)
+		return nil
+	}
+
+	uri, err := c.polarion.CreateTestRun(
+		polarionProjectID,
+		id,
+		"XUnit",
+	)
+	if err != nil {
+		return err
+	}
+
+	title := fmt.Sprintf("%s Template", c.version.String())
+	c.polarion.UpdateTestRun(uri, title, true, id)
+
+	fmt.Printf("the test run template '%s' has been created\n", id)
+	return nil
+}

--- a/cmd/polarionRelease_test.go
+++ b/cmd/polarionRelease_test.go
@@ -1,0 +1,123 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/integr8ly/delorean/pkg/polarion"
+	"github.com/integr8ly/delorean/pkg/utils"
+)
+
+type polarionSessionMock struct {
+	getPlanByID    func(projectID, id string) (*polarion.Plan, error)
+	createPlan     func(projectID, name, id, parentID, templateID string) error
+	getTestRunByID func(projectID, id string) (*polarion.TestRun, error)
+	createTestRun  func(projectID, id, templateID string) (string, error)
+	updateTestRun  func(uri string, title string, isTemplate bool, plannedIn string) error
+}
+
+func (s *polarionSessionMock) GetPlanByID(projectID, id string) (*polarion.Plan, error) {
+	return s.getPlanByID(projectID, id)
+}
+func (s *polarionSessionMock) CreatePlan(projectID, name, id, parentID, templateID string) error {
+	return s.createPlan(projectID, name, id, parentID, templateID)
+}
+func (s *polarionSessionMock) GetTestRunByID(projectID, id string) (*polarion.TestRun, error) {
+	return s.getTestRunByID(projectID, id)
+}
+func (s *polarionSessionMock) CreateTestRun(projectID, id, templateID string) (string, error) {
+	return s.createTestRun(projectID, id, templateID)
+}
+func (s *polarionSessionMock) UpdateTestRun(uri string, title string, isTemplate bool, plannedIn string) error {
+	return s.updateTestRun(uri, title, isTemplate, plannedIn)
+}
+
+func TestPolarionRelease(t *testing.T) {
+
+	cases := []struct {
+		version     string
+		session     func(t *testing.T) (polarion.PolarionSessionService, func())
+		expectError bool
+	}{
+		{
+			version: "2.1.0-rc1",
+			session: func(t *testing.T) (polarion.PolarionSessionService, func()) {
+				// Test that all mocked functions are called the right amount of times
+				calls := 0
+				return &polarionSessionMock{
+						getPlanByID:    func(_, _ string) (*polarion.Plan, error) { calls++; return &polarion.Plan{}, nil },
+						createPlan:     func(_, _, _, _, _ string) error { calls++; return nil },
+						getTestRunByID: func(_, _ string) (*polarion.TestRun, error) { calls++; return &polarion.TestRun{}, nil },
+						createTestRun:  func(_, _, _ string) (string, error) { calls++; return "uri", nil },
+						updateTestRun:  func(_, _ string, _ bool, _ string) error { calls++; return nil },
+					}, func() {
+						if expected := 7; expected != calls {
+							t.Fatalf("the session service should be called %d times but was called %d times", expected, calls)
+						}
+					}
+			},
+			expectError: false,
+		},
+		{
+			version: "2.1.0-rc1",
+			session: func(t *testing.T) (polarion.PolarionSessionService, func()) {
+				// Test an error in the polarion api
+				return &polarionSessionMock{
+					getPlanByID: func(_, _ string) (*polarion.Plan, error) { return &polarion.Plan{}, nil },
+					createPlan:  func(_, _, _, _, _ string) error { return errors.New("some error") },
+				}, func() {}
+			},
+			expectError: true,
+		},
+		{
+			version: "2.1.0",
+			session: func(t *testing.T) (polarion.PolarionSessionService, func()) {
+				// The paln should not be created if the version is not a pre-release
+				calls := 0
+				return &polarionSessionMock{
+						getPlanByID:    func(_, _ string) (*polarion.Plan, error) { calls++; return &polarion.Plan{}, nil },
+						createPlan:     func(_, _, _, _, _ string) error { calls++; return nil },
+						getTestRunByID: func(_, _ string) (*polarion.TestRun, error) { calls++; return &polarion.TestRun{}, nil },
+						createTestRun:  func(_, _, _ string) (string, error) { calls++; return "uri", nil },
+						updateTestRun:  func(_, _ string, _ bool, _ string) error { calls++; return nil },
+					}, func() {
+						if expected := 0; expected != calls {
+							t.Fatalf("the session service should be called %d times but was called %d times", expected, calls)
+						}
+					}
+			},
+			expectError: false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(fmt.Sprintf("test polarion release for version %s", c.version), func(t *testing.T) {
+
+			// Prepare the version
+			version, err := utils.NewRHMIVersion(c.version)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			session, verify := c.session(t)
+
+			// Create the polarionReleaseCmd object
+			cmd := &polarionReleaseCmd{
+				version:  version,
+				polarion: session,
+			}
+
+			// Run the polarionReleaseCmd
+			err = cmd.run()
+			if !c.expectError && err != nil {
+				t.Fatalf("polarionReleaseCmd failed with error: %s", err)
+			} else if c.expectError && err == nil {
+				t.Fatalf("polarionReleaseCmd should fails but it succed")
+			}
+
+			// Run the verify method for the mocked api
+			verify()
+		})
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,6 +69,12 @@ var pipelineCmd = &cobra.Command{
 	Long:  `Commands to run during RHMI pipelines`,
 }
 
+var reportCmd = &cobra.Command{
+	Use:   "report",
+	Short: "RHMI reporting commands",
+	Long:  "Collection of commands to report test results in Polarion and ReportPortal",
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
@@ -104,6 +110,7 @@ func init() {
 	rootCmd.AddCommand(releaseCmd)
 	rootCmd.AddCommand(ewsCmd)
 	rootCmd.AddCommand(pipelineCmd)
+	rootCmd.AddCommand(reportCmd)
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/pkg/polarion/client.go
+++ b/pkg/polarion/client.go
@@ -1,0 +1,76 @@
+package polarion
+
+import (
+	"bytes"
+	"encoding/xml"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+type Client struct {
+	url   string
+	debug bool
+}
+
+func NewClient(url string, debug bool) *Client {
+	return &Client{url: url, debug: debug}
+}
+
+func (c *Client) request(service service, request, response interface{}) error {
+
+	url := fmt.Sprintf("%s/%s", c.url, service)
+
+	p, err := xml.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	if c.debug {
+		fmt.Println("request:", string(p))
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewReader(p))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-type", "text/xml")
+	req.Header.Set("SOAPAction", "")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+
+	d, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		panic(err)
+	}
+
+	if c.debug {
+		fmt.Println("response:", string(d))
+	}
+	return xml.Unmarshal(d, response)
+}
+
+func (c *Client) LogIn(username, password string) (*LogInEnvelopResponse, error) {
+
+	request := NewLogInRequest(LogInRequestBodyLogIn{
+		UserName: username,
+		Password: password,
+	})
+
+	respose := &LogInEnvelopResponse{}
+
+	err := c.request(sessionService, request, respose)
+	if err != nil {
+		return nil, err
+	}
+
+	if respose.Body.Fault.Faultcode != "" {
+		return nil, fmt.Errorf("logIn request failed with error: %s", respose.Body.Fault.Faultstring)
+	}
+
+	return respose, nil
+}

--- a/pkg/polarion/client_test.go
+++ b/pkg/polarion/client_test.go
@@ -1,0 +1,115 @@
+package polarion
+
+import (
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"testing"
+)
+
+const projectID = "RedHatManagedIntegration"
+
+const (
+	// baseURLPath is a non-empty Client.BaseURL path to use during tests,
+	// to ensure relative URLs are used for all endpoints. See issue #752.
+	baseURLPath = "/polarion/ws/services"
+)
+
+// setup sets up a test HTTP server along with a quay.Client that is
+// configured to talk to that test server. Tests should register handlers on
+// mux which provide mock responses for the API method being tested.
+func setup() (endpoint *url.URL, mux *http.ServeMux, teardown func()) {
+	// mux is the HTTP request multiplexer used with the test server.
+	mux = http.NewServeMux()
+
+	// We want to ensure that tests catch mistakes where the endpoint URL is
+	// specified as absolute rather than relative.
+	h := http.NewServeMux()
+	h.Handle(baseURLPath+"/", http.StripPrefix(baseURLPath, mux))
+	h.HandleFunc("/", func(w http.ResponseWriter, req *http.Request) {
+		fmt.Fprintln(os.Stderr, "FAIL: Client.BaseURL path prefix is not preserved in the request URL:")
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "\t"+req.URL.String())
+		fmt.Fprintln(os.Stderr)
+		fmt.Fprintln(os.Stderr, "\tDid you accidentally use an absolute endpoint URL rather than relative?")
+		http.Error(w, "Client.BaseURL path prefix is not preserved in the request URL.", http.StatusInternalServerError)
+	})
+
+	// server is a test HTTP server used to provide mock API responses.
+	server := httptest.NewServer(h)
+
+	url, _ := url.Parse(server.URL + baseURLPath)
+
+	return url, mux, server.Close
+}
+
+func testRequest(t *testing.T, r *http.Request, expected string) {
+	t.Helper()
+
+	if got := r.Method; got != "POST" {
+		t.Errorf("the request method should be 'POST' but got '%s'", got)
+	}
+
+	got, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("failed to parse the request body with error: %s", err)
+	}
+
+	if string(got) != expected {
+		t.Errorf("the request body should match the expected body:\n  got: %s\n  expected: %s", string(got), expected)
+	}
+}
+
+func TestLogIn(t *testing.T) {
+	cases := []struct {
+		description string
+		test        func(t *testing.T)
+	}{{
+		description: "should login",
+		test: func(t *testing.T) {
+			endpoint, mux, teardown := setup()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(sessionService), func(w http.ResponseWriter, r *http.Request) {
+				testRequest(t, r, `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/" xmlns:ses="http://ws.polarion.com/SessionWebService-impl"><soapenv:Header></soapenv:Header><soapenv:Body><ses:logIn><ses:userName>test</ses:userName><ses:password>passw</ses:password></ses:logIn></soapenv:Body></soapenv:Envelope>`)
+				fmt.Fprint(w, `<Envelope><Header><sessionID>fakesessionid</sessionID></Header></Envelope>`)
+			})
+
+			polarion := NewClient(endpoint.String(), false)
+
+			r, err := polarion.LogIn("test", "passw")
+			if err != nil {
+				t.Fatalf("LogIn failed with error: %s", err)
+			}
+
+			if expected := "fakesessionid"; r.Header.SessionID != expected {
+				t.Fatalf("the response sessionID should be '%s' but got '%s'", expected, r.Header.SessionID)
+			}
+		},
+	}, {
+		description: "should fail to login",
+		test: func(t *testing.T) {
+			endpoint, mux, teardown := setup()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(sessionService), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `<Envelope><Body><Fault><faultcode>some error</faultcode></Fault></Body></Envelope>`)
+			})
+
+			polarion := NewClient(endpoint.String(), false)
+
+			_, err := polarion.LogIn("test", "passw")
+			if err == nil {
+				t.Fatalf("LogIn should fails with error")
+			}
+		},
+	},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, c.test)
+	}
+}

--- a/pkg/polarion/plan.go
+++ b/pkg/polarion/plan.go
@@ -1,0 +1,40 @@
+package polarion
+
+import "fmt"
+
+func (s *Session) GetPlanByID(projectID, id string) (*Plan, error) {
+
+	request := NewGetPlanByIDRequest(projectID, id)
+
+	response := &GetPlanByIDResponseBody{}
+
+	err := s.request(planningService, request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Fault.Faultcode != "" {
+		return nil, fmt.Errorf("getPlanById request failed with error: %s", response.Fault.Faultstring)
+	}
+
+	return &response.Plan, nil
+
+}
+
+func (s *Session) CreatePlan(projectID, name, id, parentID, templateID string) error {
+
+	request := NewCreatePlanRequest(projectID, name, id, parentID, templateID)
+
+	response := &CreatePlanResponseBody{}
+
+	err := s.request(planningService, request, response)
+	if err != nil {
+		return err
+	}
+
+	if response.Fault.Faultcode != "" {
+		return fmt.Errorf("createPlan request failed with error: %s", response.Fault.Faultstring)
+	}
+
+	return nil
+}

--- a/pkg/polarion/plan_test.go
+++ b/pkg/polarion/plan_test.go
@@ -1,0 +1,97 @@
+package polarion
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestGetPlanByID(t *testing.T) {
+	cases := []struct {
+		description string
+		test        func(t *testing.T)
+	}{{
+		description: "should retrieve the plan",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(planningService), func(w http.ResponseWriter, r *http.Request) {
+				testRequest(t, r, `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header xmlns:ses="http://ws.polarion.com/session"><ses:sessionID>fakesessionid</ses:sessionID></soapenv:Header><soapenv:Body xmlns:plan="http://ws.polarion.com/PlanningWebService-impl"><plan:getPlanById><plan:projectId>projectid</plan:projectId><plan:id>planid</plan:id></plan:getPlanById></soapenv:Body></soapenv:Envelope>`)
+				fmt.Fprint(w, `<Envelope><Body><getPlanByIdResponse><getPlanByIdReturn><id>planid</id></getPlanByIdReturn></getPlanByIdResponse></Body></Envelope>`)
+			})
+
+			plan, err := polarion.GetPlanByID("projectid", "planid")
+			if err != nil {
+				t.Fatalf("GetPlanByID failed with error: %s", err)
+			}
+
+			if expected := "planid"; plan.ID != expected {
+				t.Fatalf("the plan ID should be '%s' but got '%s'", expected, plan.ID)
+			}
+		},
+	}, {
+		description: "should fail to retrieve the plan",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(planningService), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `<Envelope><Body><Fault><faultcode>some error</faultcode></Fault></Body></Envelope>`)
+			})
+
+			_, err := polarion.GetPlanByID("projectid", "planid")
+			if err == nil {
+				t.Fatalf("GetPlanByID should fails with error")
+			}
+		},
+	},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, c.test)
+	}
+}
+
+func TestCreatePlan(t *testing.T) {
+	cases := []struct {
+		description string
+		test        func(t *testing.T)
+	}{{
+		description: "should create the plan",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(planningService), func(w http.ResponseWriter, r *http.Request) {
+				testRequest(t, r, `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header xmlns:ses="http://ws.polarion.com/session"><ses:sessionID>fakesessionid</ses:sessionID></soapenv:Header><soapenv:Body xmlns:plan="http://ws.polarion.com/PlanningWebService-impl"><plan:createPlan><plan:projectId>projectid</plan:projectId><plan:name>Plan Name</plan:name><plan:id>planid</plan:id><plan:parentId>parentid</plan:parentId><plan:templateId>templateid</plan:templateId></plan:createPlan></soapenv:Body></soapenv:Envelope>`)
+				fmt.Fprint(w, `<Envelope></Envelope>`)
+			})
+
+			err := polarion.CreatePlan("projectid", "Plan Name", "planid", "parentid", "templateid")
+			if err != nil {
+				t.Fatalf("GetPlanByID failed with error: %s", err)
+			}
+		},
+	}, {
+		description: "should fail to create the plan",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(planningService), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `<Envelope><Body><Fault><faultcode>some error</faultcode></Fault></Body></Envelope>`)
+			})
+
+			err := polarion.CreatePlan("projectid", "Plan Name", "planid", "parentid", "templateid")
+			if err == nil {
+				t.Fatalf("GetPlanByID should fails with error")
+			}
+		},
+	},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, c.test)
+	}
+}

--- a/pkg/polarion/session.go
+++ b/pkg/polarion/session.go
@@ -1,0 +1,38 @@
+package polarion
+
+type PolarionSessionService interface {
+	GetPlanByID(projectID, id string) (*Plan, error)
+	CreatePlan(projectID, name, id, parentID, templateID string) error
+	GetTestRunByID(projectID, id string) (*TestRun, error)
+	CreateTestRun(projectID, id, templateID string) (string, error)
+	UpdateTestRun(uri string, title string, isTemplate bool, plannedIn string) error
+}
+
+type Session struct {
+	client  *Client
+	session string
+}
+
+func NewSession(username, password, url string, debug bool) (*Session, error) {
+
+	client := NewClient(url, debug)
+
+	response, err := client.LogIn(username, password)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Session{
+		client:  client,
+		session: response.Header.SessionID,
+	}, nil
+}
+
+func (s *Session) request(service service, request, response interface{}) error {
+
+	req := NewSessionRequest(s.session, request)
+
+	res := &SessionResponse{Body: response}
+
+	return s.client.request(service, req, res)
+}

--- a/pkg/polarion/session_test.go
+++ b/pkg/polarion/session_test.go
@@ -1,0 +1,30 @@
+package polarion
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func setupSession() (session *Session, mux *http.ServeMux, teardown func(), err error) {
+	endpoint, mux, teardow := setup()
+
+	mux.HandleFunc("/"+string(sessionService), func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, `<Envelope><Header><sessionID>fakesessionid</sessionID></Header></Envelope>`)
+	})
+
+	session, err = NewSession("test", "passw", endpoint.String(), false)
+	if err != nil {
+		return nil, nil, func() {}, err
+	}
+
+	return session, mux, teardow, nil
+}
+
+func TestNewSession(t *testing.T) {
+	_, _, teardown, err := setupSession()
+	if err != nil {
+		t.Fatalf("failed to create a new session with error: %s", err)
+	}
+	defer teardown()
+}

--- a/pkg/polarion/test_run.go
+++ b/pkg/polarion/test_run.go
@@ -1,0 +1,57 @@
+package polarion
+
+import "fmt"
+
+func (s *Session) GetTestRunByID(projectID, id string) (*TestRun, error) {
+
+	request := NewGetTestRunByIDRequest(projectID, id)
+
+	response := &GetTestRunByIDResponseBody{}
+
+	err := s.request(testManagementService, request, response)
+	if err != nil {
+		return nil, err
+	}
+
+	if response.Fault.Faultcode != "" {
+		return nil, fmt.Errorf("getTestRunById request failed with error: %s", response.Fault.Faultstring)
+	}
+
+	return &response.TestRun, nil
+}
+
+func (s *Session) CreateTestRun(projectID, id, templateID string) (string, error) {
+
+	request := NewCreateTestRunRequest(projectID, id, templateID)
+
+	response := &CreateTestRunResponseBody{}
+
+	err := s.request(testManagementService, request, response)
+	if err != nil {
+		return "", err
+	}
+
+	if response.Fault.Faultcode != "" {
+		return "", fmt.Errorf("createTestRun request failed with error: %s", response.Fault.Faultstring)
+	}
+
+	return response.URI, nil
+}
+
+func (s *Session) UpdateTestRun(uri string, title string, isTemplate bool, plannedIn string) error {
+
+	request := NewUpdateTestRunRequest(uri, title, isTemplate, plannedIn)
+
+	response := &UpdateTestRunResponseBody{}
+
+	err := s.request(testManagementService, request, response)
+	if err != nil {
+		return err
+	}
+
+	if response.Fault.Faultcode != "" {
+		return fmt.Errorf("updateTestRun request failed with error: %s", response.Fault.Faultstring)
+	}
+
+	return nil
+}

--- a/pkg/polarion/test_run_test.go
+++ b/pkg/polarion/test_run_test.go
@@ -1,0 +1,143 @@
+package polarion
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+)
+
+func TestGetTestRunByID(t *testing.T) {
+	cases := []struct {
+		description string
+		test        func(t *testing.T)
+	}{{
+		description: "should retrieve the test run",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(testManagementService), func(w http.ResponseWriter, r *http.Request) {
+				testRequest(t, r, `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header xmlns:ses="http://ws.polarion.com/session"><ses:sessionID>fakesessionid</ses:sessionID></soapenv:Header><soapenv:Body xmlns:tes="http://ws.polarion.com/TestManagementWebService-impl"><tes:getTestRunById><tes:projectId>projectid</tes:projectId><tes:id>testrunid</tes:id></tes:getTestRunById></soapenv:Body></soapenv:Envelope>`)
+				fmt.Fprint(w, `<Envelope><Body><getTestRunByIdResponse><getTestRunByIdReturn><id>testrunid</id></getTestRunByIdReturn></getTestRunByIdResponse></Body></Envelope>`)
+			})
+
+			run, err := polarion.GetTestRunByID("projectid", "testrunid")
+			if err != nil {
+				t.Fatalf("GetTestRunByID failed with error: %s", err)
+			}
+
+			if expected := "testrunid"; run.ID != expected {
+				t.Fatalf("the test run ID should be '%s' but got '%s'", expected, run.ID)
+			}
+		},
+	}, {
+		description: "should fail to retrieve the test run",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(testManagementService), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `<Envelope><Body><Fault><faultcode>some error</faultcode></Fault></Body></Envelope>`)
+			})
+
+			_, err := polarion.GetTestRunByID("projectid", "testrunid")
+			if err == nil {
+				t.Fatalf("GetTestRunByID should fails with error")
+			}
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.description, c.test)
+	}
+}
+
+func TestCreateTestRun(t *testing.T) {
+	cases := []struct {
+		description string
+		test        func(t *testing.T)
+	}{{
+		description: "should create a test run",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(testManagementService), func(w http.ResponseWriter, r *http.Request) {
+				testRequest(t, r, `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header xmlns:ses="http://ws.polarion.com/session"><ses:sessionID>fakesessionid</ses:sessionID></soapenv:Header><soapenv:Body xmlns:tes="http://ws.polarion.com/TestManagementWebService-impl"><tes:createTestRun><tes:project>projectid</tes:project><tes:id>testrunid</tes:id><tes:template>templateid</tes:template></tes:createTestRun></soapenv:Body></soapenv:Envelope>`)
+				fmt.Fprint(w, `<Envelope><Body><createTestRunResponse><createTestRunReturn>testrunuri</createTestRunReturn></createTestRunResponse></Body></Envelope>`)
+			})
+
+			uri, err := polarion.CreateTestRun("projectid", "testrunid", "templateid")
+			if err != nil {
+				t.Fatalf("CreateTestRun failed with error: %s", err)
+			}
+
+			if expected := "testrunuri"; uri != expected {
+				t.Fatalf("the URI should be '%s' but got '%s'", expected, uri)
+			}
+		},
+	}, {
+		description: "should fail to create the test run",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(testManagementService), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `<Envelope><Body><Fault><faultcode>some error</faultcode></Fault></Body></Envelope>`)
+			})
+
+			_, err := polarion.CreateTestRun("projectid", "testrunid", "templateid")
+			if err == nil {
+				t.Fatalf("CreateTestRun should fails with error")
+			}
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.description, c.test)
+	}
+}
+
+func TestUpdateTestRun(t *testing.T) {
+	cases := []struct {
+		description string
+		test        func(t *testing.T)
+	}{{
+		description: "should update a test run",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(testManagementService), func(w http.ResponseWriter, r *http.Request) {
+				testRequest(t, r, `<soapenv:Envelope xmlns:soapenv="http://schemas.xmlsoap.org/soap/envelope/"><soapenv:Header xmlns:ses="http://ws.polarion.com/session"><ses:sessionID>fakesessionid</ses:sessionID></soapenv:Header><soapenv:Body xmlns:tes="http://ws.polarion.com/TestManagementWebService-impl" xmlns:tes1="http://ws.polarion.com/TestManagementWebService-types" xmlns:trac="http://ws.polarion.com/TrackerWebService-types"><tes:updateTestRun><tes:content uri="testrunuri"><tes1:title>Test Run</tes1:title><tes1:isTemplate>true</tes1:isTemplate><tes1:customFields><trac:Custom><trac:key>plannedin</trac:key><trac:value><trac:id>3_8_2_rc1</trac:id></trac:value></trac:Custom></tes1:customFields></tes:content></tes:updateTestRun></soapenv:Body></soapenv:Envelope>`)
+				fmt.Fprint(w, `<Envelope></Envelope>`)
+			})
+
+			err := polarion.UpdateTestRun("testrunuri", "Test Run", true, "3_8_2_rc1")
+			if err != nil {
+				t.Fatalf("UpdateTestRun failed with error: %s", err)
+			}
+
+		},
+	}, {
+		description: "should fail to update the test run",
+		test: func(t *testing.T) {
+			polarion, mux, teardown, _ := setupSession()
+			defer teardown()
+
+			mux.HandleFunc("/"+string(testManagementService), func(w http.ResponseWriter, r *http.Request) {
+				fmt.Fprint(w, `<Envelope><Body><Fault><faultcode>some error</faultcode></Fault></Body></Envelope>`)
+			})
+
+			err := polarion.UpdateTestRun("testrunuri", "Test Run", true, "3_8_2_rc1")
+			if err == nil {
+				t.Fatalf("UpdateTestRun should fails with error")
+			}
+		},
+	}}
+
+	for _, c := range cases {
+		t.Run(c.description, c.test)
+	}
+
+}

--- a/pkg/polarion/types.go
+++ b/pkg/polarion/types.go
@@ -1,0 +1,261 @@
+package polarion
+
+import "encoding/xml"
+
+type service string
+
+const (
+	sessionService        service = "SessionWebService"
+	planningService       service = "PlanningWebService"
+	testManagementService service = "TestManagementWebService"
+)
+
+type FaultBody struct {
+	Fault Fault `xml:"Fault"`
+}
+
+type Fault struct {
+	Faultcode   string `xml:"faultcode"`
+	Faultstring string `xml:"faultstring"`
+}
+
+type SessionRequest struct {
+	XMLName xml.Name             `xml:"soapenv:Envelope"`
+	SoapNS  string               `xml:"xmlns:soapenv,attr"`
+	Header  SessionRequestHeader `xml:"soapenv:Header"`
+	Body    interface{}          `xml:"soapenv:Body"`
+}
+
+type SessionRequestHeader struct {
+	SesNS     string `xml:"xmlns:ses,attr"`
+	SessionID string `xml:"ses:sessionID"`
+}
+
+type SessionResponse struct {
+	Header struct{}    `xml:"Header"`
+	Body   interface{} `xml:"Body"`
+}
+
+type LogInEnvelopResponse struct {
+	XMLName xml.Name            `xml:"Envelope"`
+	Header  LogInResponseHeader `xml:"Header"`
+	Body    FaultBody           `xml:"Body"`
+}
+
+type LogInResponseHeader struct {
+	SessionID string `xml:"sessionID"`
+}
+
+type LogInRequest struct {
+	XMLName xml.Name         `xml:"soapenv:Envelope"`
+	SoapNS  string           `xml:"xmlns:soapenv,attr"`
+	SesNS   string           `xml:"xmlns:ses,attr"`
+	Header  struct{}         `xml:"soapenv:Header"`
+	Body    LogInRequestBody `xml:"soapenv:Body"`
+}
+
+type LogInRequestBody struct {
+	LogIn LogInRequestBodyLogIn `xml:"ses:logIn"`
+}
+
+type LogInRequestBodyLogIn struct {
+	UserName string `xml:"ses:userName"`
+	Password string `xml:"ses:password"`
+}
+
+type GetPlanByIDRequestBody struct {
+	PlanNS      string             `xml:"xmlns:plan,attr"`
+	GetPlanByID GetPlanByIDRequest `xml:"plan:getPlanById"`
+}
+
+type GetPlanByIDRequest struct {
+	ProjectID string `xml:"plan:projectId"`
+	ID        string `xml:"plan:id"`
+}
+
+type GetPlanByIDResponseBody struct {
+	Plan Plan `xml:"getPlanByIdResponse>getPlanByIdReturn"`
+	FaultBody
+}
+
+type Plan struct {
+	ID         string `xml:"id"`
+	IsTemplate bool   `xml:"isTemplate"`
+	Name       string `xml:"name"`
+	Status     Status `xml:"status"`
+	Parent     *Plan  `xml:"parent"`
+}
+
+type Status struct {
+	ID string `xml:"id"`
+}
+
+type CreatePlanRequestBody struct {
+	PlanNS     string            `xml:"xmlns:plan,attr"`
+	CreatePlan CreatePlanRequest `xml:"plan:createPlan"`
+}
+
+type CreatePlanRequest struct {
+	ProjectID  string `xml:"plan:projectId"`
+	Name       string `xml:"plan:name"`
+	ID         string `xml:"plan:id"`
+	ParentID   string `xml:"plan:parentId,omitempty"`
+	TemplateID string `xml:"plan:templateId"`
+}
+
+type CreatePlanResponseBody struct {
+	FaultBody
+}
+
+type GetTestRunByIDRequestBody struct {
+	TesNS          string                `xml:"xmlns:tes,attr"`
+	GetTestRunByID GetTestRunByIDRequest `xml:"tes:getTestRunById"`
+}
+
+type GetTestRunByIDRequest struct {
+	ProjectID string `xml:"tes:projectId"`
+	ID        string `xml:"tes:id"`
+}
+
+type GetTestRunByIDResponseBody struct {
+	TestRun TestRun `xml:"getTestRunByIdResponse>getTestRunByIdReturn"`
+	FaultBody
+}
+
+type TestRun struct {
+	ID         string `xml:"id"`
+	IsTemplate bool   `xml:"isTemplate"`
+	Title      string `xml:"title"`
+	Status     Status `xml:"status"`
+}
+
+type CreateTestRunRequestBody struct {
+	TesNS         string               `xml:"xmlns:tes,attr"`
+	CreateTestRun CreateTestRunRequest `xml:"tes:createTestRun"`
+}
+
+type CreateTestRunRequest struct {
+	Project  string `xml:"tes:project"`
+	ID       string `xml:"tes:id"`
+	Template string `xml:"tes:template,omitempty"`
+}
+
+type CreateTestRunResponseBody struct {
+	URI string `xml:"createTestRunResponse>createTestRunReturn"`
+	FaultBody
+}
+
+type UpdateTestRunRequestBody struct {
+	TesNS         string               `xml:"xmlns:tes,attr"`
+	Tes1NS        string               `xml:"xmlns:tes1,attr"`
+	TracNS        string               `xml:"xmlns:trac,attr"`
+	UpdateTestRun UpdateTestRunRequest `xml:"tes:updateTestRun>tes:content"`
+}
+
+type UpdateTestRunRequest struct {
+	URI          string                            `xml:"uri,attr"`
+	Title        string                            `xml:"tes1:title,omitempty"`
+	IsTemplate   bool                              `xml:"tes1:isTemplate,omitempty"`
+	CustomFields []UpdateTestRunRequestCustomField `xml:"tes1:customFields>trac:Custom,omitempty"`
+}
+
+type UpdateTestRunRequestCustomField struct {
+	Key   string      `xml:"trac:key"`
+	Value interface{} `xml:"trac:value"`
+}
+
+type EnumOptionId struct {
+	ID string `xml:"trac:id"`
+}
+
+type UpdateTestRunResponseBody struct {
+	FaultBody
+}
+
+func NewSessionRequest(sessionID string, body interface{}) *SessionRequest {
+	return &SessionRequest{
+		SoapNS: "http://schemas.xmlsoap.org/soap/envelope/",
+		Header: SessionRequestHeader{
+			SesNS:     "http://ws.polarion.com/session",
+			SessionID: sessionID,
+		},
+		Body: body,
+	}
+}
+
+func NewLogInRequest(s LogInRequestBodyLogIn) *LogInRequest {
+	return &LogInRequest{
+		SoapNS: "http://schemas.xmlsoap.org/soap/envelope/",
+		SesNS:  "http://ws.polarion.com/SessionWebService-impl",
+		Header: struct{}{},
+		Body:   LogInRequestBody{LogIn: s},
+	}
+}
+
+func NewGetPlanByIDRequest(projectID, id string) *GetPlanByIDRequestBody {
+	return &GetPlanByIDRequestBody{
+		PlanNS: "http://ws.polarion.com/PlanningWebService-impl",
+		GetPlanByID: GetPlanByIDRequest{
+			ProjectID: projectID,
+			ID:        id,
+		},
+	}
+}
+
+func NewCreatePlanRequest(projectID, name, id, parentID, templateID string) *CreatePlanRequestBody {
+	return &CreatePlanRequestBody{
+		PlanNS: "http://ws.polarion.com/PlanningWebService-impl",
+		CreatePlan: CreatePlanRequest{
+			ProjectID:  projectID,
+			Name:       name,
+			ID:         id,
+			ParentID:   parentID,
+			TemplateID: templateID,
+		},
+	}
+}
+
+func NewGetTestRunByIDRequest(projectID, id string) *GetTestRunByIDRequestBody {
+	return &GetTestRunByIDRequestBody{
+		TesNS: "http://ws.polarion.com/TestManagementWebService-impl",
+		GetTestRunByID: GetTestRunByIDRequest{
+			ProjectID: projectID,
+			ID:        id,
+		},
+	}
+}
+
+func NewCreateTestRunRequest(projectID, id, templateID string) *CreateTestRunRequestBody {
+	return &CreateTestRunRequestBody{
+		TesNS: "http://ws.polarion.com/TestManagementWebService-impl",
+		CreateTestRun: CreateTestRunRequest{
+			Project:  projectID,
+			ID:       id,
+			Template: templateID,
+		},
+	}
+}
+
+func NewUpdateTestRunRequest(uri string, title string, isTemplate bool, plannedIn string) *UpdateTestRunRequestBody {
+
+	c := []UpdateTestRunRequestCustomField{}
+
+	if plannedIn != "" {
+		c = append(c, UpdateTestRunRequestCustomField{
+			Key:   "plannedin",
+			Value: EnumOptionId{ID: plannedIn},
+		})
+	}
+
+	return &UpdateTestRunRequestBody{
+		TesNS:  "http://ws.polarion.com/TestManagementWebService-impl",
+		Tes1NS: "http://ws.polarion.com/TestManagementWebService-types",
+		TracNS: "http://ws.polarion.com/TrackerWebService-types",
+		UpdateTestRun: UpdateTestRunRequest{
+			URI:          uri,
+			Title:        title,
+			IsTemplate:   isTemplate,
+			CustomFields: c,
+		},
+	}
+}

--- a/pkg/utils/rhmi_version.go
+++ b/pkg/utils/rhmi_version.go
@@ -77,6 +77,18 @@ func (v *RHMIVersion) MajorMinor() string {
 	return fmt.Sprintf("%s.%s", v.major, v.minor)
 }
 
+func (v *RHMIVersion) MajorMinorPatch() string {
+	return fmt.Sprintf("%s.%s", v.MajorMinor(), v.patch)
+}
+
+func (v *RHMIVersion) PolarionReleaseId() string {
+	return fmt.Sprintf("v%s_%s_%s", v.major, v.minor, v.patch)
+}
+
+func (v *RHMIVersion) PolarionMilestoneId() string {
+	return fmt.Sprintf("%s_%s", v.PolarionReleaseId(), v.build)
+}
+
 func (v *RHMIVersion) PrepareReleaseBranchName() string {
 	return fmt.Sprintf(releaseBranchNameTemplate, v.TagName())
 }


### PR DESCRIPTION
**Try:**

1. Add your `polarion_username` and `polarion_password` to the *~/.delorean.yaml*

   ```yaml
   polarion_username: kerberosid
   polarion_password: kerberospassword
   ```

2. Create a new release

   ```
   delorean report polarion-release  --version "3.9.1-er1" --stage
   ```

   > A new Plan, Milestone, and Template should be created in the staging environment
   >
   > https://polarion.stage.engineering.redhat.com/polarion/#/project/RedHatManagedIntegration/plans

3. Create a new build

   ```
   delorean report polarion-release  --version "3.9.1-er2" --stage
   ```

   > A new Milestone, and Template should be created

4. Run the script again
   
   > The script should succeed and the creation of the Plan, Milestone, and Template should be skipped

**Todo:**
- [x] Add tests for the Polarion API
- [x] Add tests for the polarion-release cmd
- [x] Add `--stage` and `--debug` flags
- [x] Rebase and squash all commits