### PR TITLE
add get and set for relatedImages

### DIFF
--- a/cmd/processCSVImages_test.go
+++ b/cmd/processCSVImages_test.go
@@ -225,6 +225,80 @@ func TestProcessCSVImages(t *testing.T) {
 				return nil
 			}, wantErr: false,
 		},
+		{
+			name:                 "Ensure relatedImages converted to production (isGA=true)",
+			tstCreateManifestDir: "../pkg/utils/testdata/validManifests/crw",
+			args: args{
+				ctx:        context.TODO(),
+				processCSV: mockProcessCSVImages,
+				cmdOpts: &processCSVImagesCmdOptions{
+					isGa: true,
+				}},
+			verify: func(t *testing.T, manifestDir string) error {
+				_, csvFile, err := utils.GetCurrentCSV(manifestDir)
+				if err != nil {
+					return err
+				}
+
+				b, err := ioutil.ReadFile(csvFile)
+				if err != nil {
+					panic(err)
+				}
+
+				relatedImages := []string{
+					"registry.stage.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:02e8777fa295e6615bbd73f3d92911e7e7029b02cdf6346eba502aaeb8fe3de1",
+				    "registry.stage.redhat.io/codeready-workspaces/server-rhel8@sha256:f7b27fb525a24c4273f0a3e18461a70f3cbb897e845e44abd8ca10fd1de3e1b2",
+					"registry.stage.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:6cd737a9e9df54407959a0e8e4bb6a3e3b9e37cf590193545f609b2c4af4bf46",
+					"registry.stage.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:0124562131e8cde6b2b9a5e4bced93522da3c1c95e9122306ecd8acb093650e0",
+					"registry.stage.redhat.io/ubi8-minimal@sha256:9285da611437622492f9ef4229877efe302589f1401bbd4052e9bb261b3d4387",
+					"registry.stage.redhat.io/rhscl/postgresql-96-rhel7@sha256:196abd9a1221fb38dd5693203f068fc4d520bb351928ef84e5e15984f5152476",
+					"registry.stage.redhat.io/redhat-sso-7/sso73-openshift@sha256:0dc950903bbc971c14e6223efe3493f0f50eb8af7cbe91aeea621f80f99f155f",
+					"registry.stage.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:6c9abe63a70a6146dc49845f2f7732e3e6e0bcae6a19c3a6557367d6965bc1f8",
+					"registry.stage.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:5815bab69fc343cbf6dac0fd67dd70a25757fac08689a15e4a762655fa2e8a2c",
+				}
+				for _, image := range relatedImages {
+					imageFound, err := regexp.Match(image, b)
+					if err != nil {
+						return err
+					}
+					if imageFound {
+						t.Errorf("found %v in relatedImages", image)
+					}
+				}
+				return nil
+			}, wantErr: false,
+		},
+		{
+			name:                 "Ensure relatedImages field not added",
+			tstCreateManifestDir: "../pkg/utils/testdata/validManifests/3scale",
+			args: args{
+				ctx:        context.TODO(),
+				processCSV: mockProcessCSVImages,
+				cmdOpts: &processCSVImagesCmdOptions{
+					isGa: true,
+				}},
+			verify: func(t *testing.T, manifestDir string) error {
+				_, csvFile, err := utils.GetCurrentCSV(manifestDir)
+				if err != nil {
+					return err
+				}
+
+				b, err := ioutil.ReadFile(csvFile)
+				if err != nil {
+					panic(err)
+				}
+
+				fieldFound, err := regexp.Match("relatedImages", b)
+				if err != nil {
+					return err
+				}
+				if fieldFound {
+					t.Errorf("found relatedImages field in CSV")
+				}
+
+				return nil
+			}, wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/cmd/processCSVImages_test.go
+++ b/cmd/processCSVImages_test.go
@@ -247,7 +247,7 @@ func TestProcessCSVImages(t *testing.T) {
 
 				relatedImages := []string{
 					"registry.stage.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:02e8777fa295e6615bbd73f3d92911e7e7029b02cdf6346eba502aaeb8fe3de1",
-				    "registry.stage.redhat.io/codeready-workspaces/server-rhel8@sha256:f7b27fb525a24c4273f0a3e18461a70f3cbb897e845e44abd8ca10fd1de3e1b2",
+					"registry.stage.redhat.io/codeready-workspaces/server-rhel8@sha256:f7b27fb525a24c4273f0a3e18461a70f3cbb897e845e44abd8ca10fd1de3e1b2",
 					"registry.stage.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:6cd737a9e9df54407959a0e8e4bb6a3e3b9e37cf590193545f609b2c4af4bf46",
 					"registry.stage.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:0124562131e8cde6b2b9a5e4bced93522da3c1c95e9122306ecd8acb093650e0",
 					"registry.stage.redhat.io/ubi8-minimal@sha256:9285da611437622492f9ef4229877efe302589f1401bbd4052e9bb261b3d4387",

--- a/pkg/utils/csv.go
+++ b/pkg/utils/csv.go
@@ -34,6 +34,12 @@ type csvName struct {
 	Name    string
 	Version semver.Version
 }
+
+type relatedImage struct {
+	Name  string
+	Image string
+}
+
 type csvNames []csvName
 
 func (c csvNames) Len() int           { return len(c) }
@@ -129,6 +135,36 @@ func (csv *CSV) SetOperatorDeploymentSpec(deploymentSpec *olmapiv1alpha1.Strateg
 
 func (csv *CSV) SetReplaces(replaces string) error {
 	return unstructured.SetNestedField(csv.obj.Object, replaces, "spec", "replaces")
+}
+
+func (csv *CSV) GetRelatedImages() ([]relatedImage, error) {
+	relatedImages, _, err := unstructured.NestedSlice(csv.obj.Object, "spec", "relatedImages")
+	if err != nil {
+		return nil, err
+	}
+	ri := make([]relatedImage, len(relatedImages))
+	for k, v := range relatedImages {
+		i := &relatedImage{}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(v.(map[string]interface{}), i)
+		if err != nil {
+			return nil, err
+		}
+
+		ri[k] = *i
+	}
+	return ri, nil
+}
+
+func (csv *CSV) SetRelatedImages(relatedImages []relatedImage) error {
+	ri := make([]interface{}, len(relatedImages))
+	for k, v := range relatedImages {
+		s, err := runtime.DefaultUnstructuredConverter.ToUnstructured(&v)
+		if err != nil {
+			return err
+		}
+		ri[k] = s
+	}
+	return unstructured.SetNestedSlice(csv.obj.Object, ri, "spec", "relatedImages")
 }
 
 func (csv *CSV) UpdateEnvVarList(envKeyValMap map[string]string) error {
@@ -343,6 +379,7 @@ func GetAndUpdateOperandImages(manifestDir string, extraImages []string, isGa bo
 
 	var images = map[string]string{}
 	deployment, err := csv.GetOperatorDeploymentSpec()
+	relatedImages, err := csv.GetRelatedImages()
 	if err != nil {
 		return nil, err
 	}
@@ -374,6 +411,29 @@ func GetAndUpdateOperandImages(manifestDir string, extraImages []string, isGa bo
 			}
 		}
 	}
+
+	// Check that relatedImages all point to the correct registry if isGa
+	if isGa && len(relatedImages) > 0 {
+		for k, i := range relatedImages {
+			if strings.Contains(i.Image, "registry.stage.redhat.io") {
+				relatedImages[k].Image = strings.Replace(i.Image, "registry.stage.redhat.io", "registry.redhat.io", 1)
+			}
+
+			if strings.Contains(i.Image, "quay.io/integreatly/delorean") {
+				relatedImages[k].Image = strings.Replace(i.Image, "quay.io/integreatly/delorean", "registry.redhat.io", 1)
+			}
+
+			if strings.Contains(i.Image, "registry-proxy.engineering.redhat.com") {
+				relatedImages[k].Image = strings.Replace(i.Image, "registry-proxy.engineering.redhat.com", "registry.redhat.io", 1)
+			}
+		}
+
+		err = csv.SetRelatedImages(relatedImages)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	csv.SetOperatorDeploymentSpec(deployment)
 
 	err = csv.WriteYAML(fp)

--- a/pkg/utils/csv.go
+++ b/pkg/utils/csv.go
@@ -40,6 +40,11 @@ type relatedImage struct {
 	Image string
 }
 
+type relatedImageValue struct {
+	Name  string
+	Value string
+}
+
 type csvNames []csvName
 
 func (c csvNames) Len() int           { return len(c) }
@@ -145,13 +150,28 @@ func (csv *CSV) GetRelatedImages() ([]relatedImage, error) {
 	ri := make([]relatedImage, len(relatedImages))
 	for k, v := range relatedImages {
 		i := &relatedImage{}
+		vi := &relatedImageValue{}
+
 		err = runtime.DefaultUnstructuredConverter.FromUnstructured(v.(map[string]interface{}), i)
 		if err != nil {
 			return nil, err
 		}
+		err = runtime.DefaultUnstructuredConverter.FromUnstructured(v.(map[string]interface{}), vi)
+		if err != nil {
+			return nil, err
+		}
+
+		if vi.Value != "" {
+			i = &relatedImage{
+				Name:  vi.Name,
+				Image: vi.Value,
+			}
+
+		}
 
 		ri[k] = *i
 	}
+
 	return ri, nil
 }
 

--- a/pkg/utils/csv.go
+++ b/pkg/utils/csv.go
@@ -418,14 +418,6 @@ func GetAndUpdateOperandImages(manifestDir string, extraImages []string, isGa bo
 			if strings.Contains(i.Image, "registry.stage.redhat.io") {
 				relatedImages[k].Image = strings.Replace(i.Image, "registry.stage.redhat.io", "registry.redhat.io", 1)
 			}
-
-			if strings.Contains(i.Image, "quay.io/integreatly/delorean") {
-				relatedImages[k].Image = strings.Replace(i.Image, "quay.io/integreatly/delorean", "registry.redhat.io", 1)
-			}
-
-			if strings.Contains(i.Image, "registry-proxy.engineering.redhat.com") {
-				relatedImages[k].Image = strings.Replace(i.Image, "registry-proxy.engineering.redhat.com", "registry.redhat.io", 1)
-			}
 		}
 
 		err = csv.SetRelatedImages(relatedImages)

--- a/pkg/utils/testdata/validManifests/crw/v2.1.1/codeready-workspaces.csv.yaml
+++ b/pkg/utils/testdata/validManifests/crw/v2.1.1/codeready-workspaces.csv.yaml
@@ -420,31 +420,31 @@ spec:
   version: 2.1.1
   relatedImages:
     - name: crw-2-rhel8-operator
-      image: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:02e8777fa295e6615bbd73f3d92911e7e7029b02cdf6346eba502aaeb8fe3de1
+      image: registry.stage.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:02e8777fa295e6615bbd73f3d92911e7e7029b02cdf6346eba502aaeb8fe3de1
       # tag: registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator:2.1
     - name: server-rhel8
-      image: registry.redhat.io/codeready-workspaces/server-rhel8@sha256:f7b27fb525a24c4273f0a3e18461a70f3cbb897e845e44abd8ca10fd1de3e1b2
+      image: registry.stage.redhat.io/codeready-workspaces/server-rhel8@sha256:f7b27fb525a24c4273f0a3e18461a70f3cbb897e845e44abd8ca10fd1de3e1b2
       # tag: registry.redhat.io/codeready-workspaces/server-rhel8:2.1
     - name: codeready-workspaces-pluginregistry-rhel8
-      image: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:6cd737a9e9df54407959a0e8e4bb6a3e3b9e37cf590193545f609b2c4af4bf46
+      image: registry.stage.redhat.io/codeready-workspaces/pluginregistry-rhel8@sha256:6cd737a9e9df54407959a0e8e4bb6a3e3b9e37cf590193545f609b2c4af4bf46
       # tag: registry.redhat.io/codeready-workspaces/pluginregistry-rhel8:2.1
     - name: codeready-workspaces-devfileregistry-rhel8
-      image: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:0124562131e8cde6b2b9a5e4bced93522da3c1c95e9122306ecd8acb093650e0
+      image: registry.stage.redhat.io/codeready-workspaces/devfileregistry-rhel8@sha256:0124562131e8cde6b2b9a5e4bced93522da3c1c95e9122306ecd8acb093650e0
       # tag: registry.redhat.io/codeready-workspaces/devfileregistry-rhel8:2.1
     - name: ubi8-minimal
-      image: registry.access.redhat.com/ubi8-minimal@sha256:9285da611437622492f9ef4229877efe302589f1401bbd4052e9bb261b3d4387
+      image: registry.stage.redhat.io/ubi8-minimal@sha256:9285da611437622492f9ef4229877efe302589f1401bbd4052e9bb261b3d4387
       # tag: registry.access.redhat.com/ubi8-minimal:8.1-398
     - name: postgresql-96-rhel7
-      image: registry.redhat.io/rhscl/postgresql-96-rhel7@sha256:196abd9a1221fb38dd5693203f068fc4d520bb351928ef84e5e15984f5152476
+      image: registry.stage.redhat.io/rhscl/postgresql-96-rhel7@sha256:196abd9a1221fb38dd5693203f068fc4d520bb351928ef84e5e15984f5152476
       # tag: registry.redhat.io/rhscl/postgresql-96-rhel7:1-47
     - name: sso73-openshift
-      image: registry.redhat.io/redhat-sso-7/sso73-openshift@sha256:0dc950903bbc971c14e6223efe3493f0f50eb8af7cbe91aeea621f80f99f155f
+      image: registry.stage.redhat.io/redhat-sso-7/sso73-openshift@sha256:0dc950903bbc971c14e6223efe3493f0f50eb8af7cbe91aeea621f80f99f155f
       # tag: registry.redhat.io/redhat-sso-7/sso73-openshift:1.0-15
     - name: pluginbroker-metadata-rhel8
-      image: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:6c9abe63a70a6146dc49845f2f7732e3e6e0bcae6a19c3a6557367d6965bc1f8
+      image: registry.stage.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8@sha256:6c9abe63a70a6146dc49845f2f7732e3e6e0bcae6a19c3a6557367d6965bc1f8
       # tag: registry.redhat.io/codeready-workspaces/pluginbroker-metadata-rhel8:2.1
     - name: pluginbroker-artifacts-rhel8
-      image: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:5815bab69fc343cbf6dac0fd67dd70a25757fac08689a15e4a762655fa2e8a2c
+      image: registry.stage.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8@sha256:5815bab69fc343cbf6dac0fd67dd70a25757fac08689a15e4a762655fa2e8a2c
       # tag: registry.redhat.io/codeready-workspaces/pluginbroker-artifacts-rhel8:2.1
     - name: jwtproxy-rhel8
       image: registry.redhat.io/codeready-workspaces/jwtproxy-rhel8@sha256:63182dae6377ac01fbebdcb9c6a4435681ea88521cfc6e4222fe3920a3641127


### PR DESCRIPTION
If isGa and there are relatedImages found, replace any reference to the staging registries with the production registry.

*To Verify*
1. change images in relatedImages section in `pkg/utils/testdata/validManifests/3scale/0.4.0/3scale-operator.v0.4.0.clusterserviceversion.yaml` to point to staging registries
2. Run `./delorean ews process-csv-images -m pkg/utils/testdata/validManifests/3scale/ -g`
3. Verify all relatedImages now point to `registry.redhat.io`