### PR TITLE
Fix ose cli osbs image generation.

### DIFF
--- a/pkg/utils/images.go
+++ b/pkg/utils/images.go
@@ -49,6 +49,11 @@ func BuildOSBSImage(image string) string {
 		return image
 	}
 
+	if crw[0] == "ose-cli" {
+		image = osbsRegistry + "/openshift-ose-cli@" + crw[1]
+		return image
+	}
+
 	//we need to treat the amq broker image differently
 	amq := strings.Split(image, ":")
 	imagename := strings.Split(amq[0], "/")

--- a/pkg/utils/images_test.go
+++ b/pkg/utils/images_test.go
@@ -76,6 +76,11 @@ func TestBuildOSBSImage(t *testing.T) {
 			"registry.redhat.io/codeready-workspaces/crw-2-rhel8-operator@sha256:02e8777fa295e6615bbd73f3d92911e7e7029b02cdf6346eba502aaeb8fe3de1",
 			"registry-proxy.engineering.redhat.com/rh-osbs/codeready-workspaces-operator@sha256:02e8777fa295e6615bbd73f3d92911e7e7029b02cdf6346eba502aaeb8fe3de1",
 		},
+		{
+			"test openshift4-ose-cli",
+			"registry.redhat.io/openshift4/ose-cli@sha256:353036a27e810730ce35d699dcf09141af9f8ae9e365116755016d864475c2c4",
+			"registry-proxy.engineering.redhat.com/rh-osbs/openshift-ose-cli@sha256:353036a27e810730ce35d699dcf09141af9f8ae9e365116755016d864475c2c4",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
The latest 3scale CSV has a new image dependency that doesn't quite follow the same osbs naming as everything else.

No JIRA, but will link into the product update JIRA that will be generated once this is merged.