### PR TITLE
Updated script to remove need for NAMESPACE_PREFIX 

### DIFF
--- a/scripts/ocm/measure-downtime.js
+++ b/scripts/ocm/measure-downtime.js
@@ -5,12 +5,12 @@ const exec = util.promisify(require('child_process').exec);
 let projects = []; // used to store all projects that will be monitored (along with their dcs, deployments and statefulsets (if any))
 let keepRunning = true; // boolean flag used to control the monitoring loop
 const start = getCurrentEpochTimestamp();
-let NAMESPACE_PREFIX;
+let NAMESPACE_PREFIX = process.env.NAMESPACE_PREFIX || '';
 
 monitorDowntime();
 
 async function monitorDowntime(){
-  await getNamespacePrefix();
+ (NAMESPACE_PREFIX === '') ? await getNamespacePrefix() : null;
   startMonitorDowntime();
 }
 

--- a/scripts/ocm/measure-downtime.js
+++ b/scripts/ocm/measure-downtime.js
@@ -15,7 +15,7 @@ async function monitorDowntime(){
 }
 
 async function getNamespacePrefix(){
-  let ns = await exec(`oc get namespaces --all-namespaces | grep fuse`);
+  let ns = await exec(`oc get namespaces --all-namespaces | grep user-sso`);
   let stdout = ns.stdout;
   (stdout.includes('redhat-rhmi-')) ? NAMESPACE_PREFIX = 'redhat-rhmi-' : (stdout.includes('openshift-')) ? NAMESPACE_PREFIX = 'openshift-' : NAMESPACE_PREFIX = '';
 }


### PR DESCRIPTION
The script can now be run without the need to set the NAMESPACE_PREFIX env variable.

**Verification Steps**
1. clone this repo
2. cd delorean/scripts/ocm
3. oc login to RHMI 1.x cluster
4. node measure-downtime.js   // output should show openshift- prefixed namespaces from cluster being monitored
5. ctl-C
6. oc long to RHMI 2.x cluster
7. node measure-downtime.js   //  output shuld show redhat-rhmi- prefixed namespaces from cluster being monitored
9. ctl-C 

**Console Output from RHMI 1.x run**
`Tony@WorkMac: ~/delorean/scripts/ocm (removeEnvVariableFromDowntimeMeasure) $ node measure-downtime.js 
Getting initial list of RHMI components

Getting available deployments, dcs and statefulsets... done
Checking readiness of deployment configs in openshift-3scale namespace...
Checking readiness of deployment configs in openshift-ansible-service-broker namespace...
Checking readiness of deployment configs in openshift-apicurito namespace...
Checking readiness of deployment configs in openshift-enmasse namespace...
Checking readiness of deployment configs in openshift-fuse namespace...
Checking readiness of deployment configs in openshift-launcher namespace...
Checking readiness of deployment configs in openshift-logging namespace...
Checking readiness of deployment configs in openshift-sso namespace...
Checking readiness of deployment configs in openshift-user-sso namespace...
Checking readiness of deployment configs in openshift-webapp namespace...
Persisting current JSON data to downtime.json file... 
Getting available deployments, dcs and statefulsets... done
Checking readiness of deployment configs in openshift-3scale namespace...
Checking readiness of deployment configs in openshift-ansible-service-broker namespace...
Checking readiness of deployment configs in openshift-apicurito namespace...
Checking readiness of deployment configs in openshift-enmasse namespace...
Checking readiness of deployment configs in openshift-fuse namespace...
Checking readiness of deployment configs in openshift-launcher namespace...
Checking readiness of deployment configs in openshift-logging namespace...
Checking readiness of deployment configs in openshift-sso namespace...
Checking readiness of deployment configs in openshift-user-sso namespace...
Checking readiness of deployment configs in openshift-webapp namespace...
Persisting current JSON data to downtime.json file... 
Getting available deployments, dcs and statefulsets... ^CCaught interrupt signal
Unable to get deployments: Error: Command failed: oc get statefulset --all-namespaces | awk '{print $1,$2,$3}'

done
Checking readiness of deployment configs in openshift-3scale namespace...
Checking readiness of deployment configs in openshift-ansible-service-broker namespace...
Checking readiness of deployment configs in openshift-apicurito namespace...
Checking readiness of deployment configs in openshift-enmasse namespace...
Checking readiness of deployment configs in openshift-fuse namespace...
Checking readiness of deployment configs in openshift-launcher namespace...
Checking readiness of deployment configs in openshift-logging namespace...
Checking readiness of deployment configs in openshift-sso namespace...
Checking readiness of deployment configs in openshift-user-sso namespace...
Checking readiness of deployment configs in openshift-webapp namespace...
Persisting current JSON data to downtime.json file...`

**Console Output from RHMI 2.x run**
`node measure-downtime.js Getting initial list of RHMI components

Getting available deployments, dcs and statefulsets... done
Checking readiness of deployment configs in redhat-rhmi-3scale namespace...
Checking readiness of deployments in redhat-rhmi-3scale-operator namespace...
Checking readiness of deployments in redhat-rhmi-amq-online namespace...
Checking readiness of deployment configs in redhat-rhmi-apicurito namespace...
Checking readiness of deployments in redhat-rhmi-apicurito namespace...
Checking readiness of deployments in redhat-rhmi-apicurito-operator namespace...
Checking readiness of deployments in redhat-rhmi-cloud-resources-operator namespace...
Checking readiness of deployments in redhat-rhmi-codeready-workspaces namespace...
Checking readiness of deployments in redhat-rhmi-codeready-workspaces-operator namespace...
Checking readiness of deployment configs in redhat-rhmi-fuse namespace...
Checking readiness of deployments in redhat-rhmi-fuse-operator namespace...
Checking readiness of deployments in redhat-rhmi-middleware-monitoring-operator namespace...
Checking readiness of statefulsets in redhat-rhmi-middleware-monitoring-operator namespace...
Checking readiness of deployments in redhat-rhmi-operator namespace...
Checking readiness of statefulsets in redhat-rhmi-rhsso namespace...
Checking readiness of deployments in redhat-rhmi-rhsso-operator namespace...
Checking readiness of deployment configs in redhat-rhmi-solution-explorer namespace...
Checking readiness of deployments in redhat-rhmi-solution-explorer-operator namespace...
Checking readiness of deployments in redhat-rhmi-ups namespace...
Checking readiness of deployments in redhat-rhmi-ups-operator namespace...
Checking readiness of statefulsets in redhat-rhmi-user-sso namespace...
Checking readiness of deployments in redhat-rhmi-user-sso-operator namespace...
Persisting current JSON data to downtime.json file... 
Getting available deployments, dcs and statefulsets... done
Checking readiness of deployment configs in redhat-rhmi-3scale namespace...
Checking readiness of deployments in redhat-rhmi-3scale-operator namespace...
Checking readiness of deployments in redhat-rhmi-amq-online namespace...
Checking readiness of deployment configs in redhat-rhmi-apicurito namespace...
Checking readiness of deployments in redhat-rhmi-apicurito namespace...
Checking readiness of deployments in redhat-rhmi-apicurito-operator namespace...
Checking readiness of deployments in redhat-rhmi-cloud-resources-operator namespace...
Checking readiness of deployments in redhat-rhmi-codeready-workspaces namespace...
Checking readiness of deployments in redhat-rhmi-codeready-workspaces-operator namespace...
Checking readiness of deployment configs in redhat-rhmi-fuse namespace...
Checking readiness of deployments in redhat-rhmi-fuse-operator namespace...
Checking readiness of deployments in redhat-rhmi-middleware-monitoring-operator namespace...
Checking readiness of statefulsets in redhat-rhmi-middleware-monitoring-operator namespace...
Checking readiness of deployments in redhat-rhmi-operator namespace...
Checking readiness of statefulsets in redhat-rhmi-rhsso namespace...
Checking readiness of deployments in redhat-rhmi-rhsso-operator namespace...
Checking readiness of deployment configs in redhat-rhmi-solution-explorer namespace...
Checking readiness of deployments in redhat-rhmi-solution-explorer-operator namespace...
Checking readiness of deployments in redhat-rhmi-ups namespace...
Checking readiness of deployments in redhat-rhmi-ups-operator namespace...
Checking readiness of statefulsets in redhat-rhmi-user-sso namespace...
Checking readiness of deployments in redhat-rhmi-user-sso-operator namespace...
Persisting current JSON data to downtime.json file... 
Getting available deployments, dcs and statefulsets... done`