### PR TITLE
adding note on versioning limitations due to new network configuration in cro

### DIFF
--- a/docs/ocm/README.md
+++ b/docs/ocm/README.md
@@ -10,6 +10,9 @@ If you want to test your changes on a cluster, the easiest solution would be to 
 * :apple: (Mac users) - install `gtimeout` util and create a symbolic link (so it can be referenced as `timeout`): 
   * `brew install coreutils && sudo ln -s /usr/local/bin/gtimeout /usr/local/bin/timeout`
 
+NOTE: Due to a change in how networking is configured for openshift in v4.4.6 (mentioned in the [cloud resource operator](https://github.com/integr8ly/cloud-resource-operator#supported-openshift-versions)) there is a limitation on the version of Openshift that RHMI can be installed on for BYOC clusters.
+Due to this change the use of integreatly-operator <= v2.4.0 on Openshift >= v4.4.6 is unsupported. Please use >= v2.5.0 of integreatly-operator for Openshift >= v4.4.6.
+
 ### Steps
 
 1. Download the OCM CLI tool and add it to your PATH
@@ -20,6 +23,7 @@ make ocm/login
 ```
 
 **BYOC**
+
 If you want to setup a BYOC cluster, you will need an AWS root account with no OSD cluster running in it. The AWS account needs an IAM user named `osdCcsAdmin` and this user needs the AdministratorAccess permission.
 
 Once this user is in place and no other OSD cluster is running in the account, you will need the AWS credentials (`AWS_ACCOUNT_ID`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`) for the `osdCcsAdmin` user to use in your cluster request.
@@ -37,7 +41,8 @@ export BYOC=true
 This command will generate `ocm/cluster.json` file with generated cluster name. This file will be used as a template to create your cluster via OCM CLI.
 By default, it will set the expiration timestamp for a cluster for 4 hours, meaning your cluster will be automatically deleted after 4 hours after you generated this template. If you want to change the default timestamp, you can update it in `ocm/cluster.json` or delete the whole line from the file if you don't want your cluster to be deleted automatically at all.
 
-**BYOC**
+**/BYOC**
+
 If you exported AWS credentials (like described in the previous step), your cluster configuration will also include the AWS credentials and `byoc` field
 set to `true`.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/INTLY-5160

Adding a note regarding the limitation of installing older versions of RHMI to version => 4.4.6 of Openshift, giving the cluster creator the opportunity to create an older cluster should they need it.

Related pr here: https://github.com/integr8ly/integreatly-operator/pull/1005