### PR TITLE
fix: cluster-service: wait for deletion

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -187,7 +187,7 @@ delete_cluster() {
 
         cluster_region=$(get_cluster_region)
         echo "Cleaning up RHMI AWS resources for the cluster with infra ID: ${infra_id}, region: ${cluster_region}, AWS Account ID: ${AWS_ACCOUNT_ID}"
-        cluster-service cleanup "${infra_id}" --region="${cluster_region}" --dry-run=false
+        cluster-service cleanup "${infra_id}" --region="${cluster_region}" --dry-run=false --watch
     fi
 }
 


### PR DESCRIPTION
### Motivation
https://issues.redhat.com/browse/INTLY-9466
https://github.com/integr8ly/cluster-service/pull/15

tl;dr: `--watch` flag allows cluster-service delete to RHMI VPCs, that can't be deleted on a single run of this command, because they are protected from deletion by dependant AWS resources (RDS and Elasticache)