### PR TITLE
add cmd to check OLM graph

### DIFF
--- a/cmd/checkOLMGraph.go
+++ b/cmd/checkOLMGraph.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"github.com/spf13/cobra"
+	"io/ioutil"
+	"path"
+)
+
+type checkOLMGraphFlags struct {
+	directory string
+}
+
+type checkOLMGraphCmd struct {
+	directory string
+	csvs      map[string]utils.CSVNames
+}
+
+func init() {
+	f := &checkOLMGraphFlags{}
+	cmd := &cobra.Command{
+		Use:   "check-olm-graph",
+		Short: "Check if the OLM graph chain is broken for a given OLM manifest directory",
+		Run: func(cmd *cobra.Command, args []string) {
+			c, err := newCheckOLMGraphCmd(f)
+			if err != nil {
+				handleError(err)
+			}
+			if err := c.run(cmd.Context()); err != nil {
+				handleError(err)
+			}
+		},
+	}
+
+	ewsCmd.AddCommand(cmd)
+	cmd.Flags().StringVarP(&f.directory, "directory", "d", "", "Path to the OLM manifest directory")
+	cmd.MarkFlagRequired("directory")
+}
+
+func newCheckOLMGraphCmd(f *checkOLMGraphFlags) (*checkOLMGraphCmd, error) {
+	csvs := make(map[string]utils.CSVNames)
+	dirs, err := ioutil.ReadDir(f.directory)
+	if err != nil {
+		return nil, err
+	}
+	for _, d := range dirs {
+		if d.IsDir() {
+			p := path.Join(f.directory, d.Name())
+			c, err := utils.GetSortedCSVNames(p)
+			if err != nil {
+				return nil, err
+			}
+			csvs[d.Name()] = c
+		}
+	}
+
+	return &checkOLMGraphCmd{
+		directory: f.directory,
+		csvs:      csvs,
+	}, err
+}
+
+func (c *checkOLMGraphCmd) run(ctx context.Context) error {
+	var hasError bool
+	for dir, csvs := range c.csvs {
+		err := checkGraphInDir(dir, csvs)
+		if err != nil {
+			hasError = true
+		}
+	}
+	if hasError {
+		return errors.New(fmt.Sprintf("OLM graph check failed in %s", c.directory))
+	}
+	return nil
+}
+
+func checkGraphInDir(dirname string, csvs utils.CSVNames) error {
+	if csvs.Len() <= 1 {
+		fmt.Println(fmt.Sprintf("[%s] no graph to check", dirname))
+		return nil
+	}
+	for i := csvs.Len() - 1; i > 0; i-- {
+		csv := csvs[i]
+		if !csvs.Contains(csv.Replaces) {
+			fmt.Println(fmt.Sprintf("[%s] OLM graph is broken. CSV %s replaces %s, which doesn't exist", dirname, csv.Name, csv.Replaces))
+			return errors.New(fmt.Sprintf("[%s] invalid replaces field %s in CSV %s", dirname, csv.Replaces, csv.Name))
+		}
+	}
+	fmt.Println(fmt.Sprintf("[%s] OLM graph is complete", dirname))
+	return nil
+}

--- a/cmd/checkOLMGraph_test.go
+++ b/cmd/checkOLMGraph_test.go
@@ -1,0 +1,98 @@
+package cmd
+
+import (
+	"context"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"testing"
+)
+
+func TestCheckOLMGraphCmd(t *testing.T) {
+	cases := []struct {
+		description string
+		csvs        utils.CSVNames
+		expectError bool
+	}{
+		{
+			description: "success",
+			csvs: utils.CSVNames{
+				{
+					Name:     "operator.v1.0.1",
+					Replaces: "operator.v1.0.0",
+				},
+			},
+			expectError: false,
+		},
+		{
+			description: "success",
+			csvs: utils.CSVNames{
+				{
+					Name:     "operator.v1.0.1",
+					Replaces: "",
+				},
+				{
+					Name:     "operator.v1.0.2",
+					Replaces: "operator.v1.0.1",
+				},
+				{
+					Name:     "operator.v1.0.3",
+					Replaces: "operator.v1.0.2",
+				},
+			},
+			expectError: false,
+		},
+		{
+			description: "success",
+			csvs: utils.CSVNames{
+				{
+					Name:     "operator.v1.0.1",
+					Replaces: "",
+				},
+				{
+					Name:     "operator.v1.0.2",
+					Replaces: "operator.v1.0.1",
+				},
+				{
+					Name:     "operator.v1.0.3",
+					Replaces: "operator.v1.0.1",
+				},
+			},
+			expectError: false,
+		},
+		{
+			description: "failure",
+			csvs: utils.CSVNames{
+				{
+					Name:     "operator.v1.0.1",
+					Replaces: "operator.v1.0.0",
+				},
+				{
+					Name:     "operator.v1.0.2",
+					Replaces: "operator.v1.0.0",
+				},
+				{
+					Name:     "operator.v1.0.4",
+					Replaces: "operator.v1.0.3",
+				},
+			},
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.description, func(t *testing.T) {
+			cmd := &checkOLMGraphCmd{
+				csvs: map[string]utils.CSVNames{
+					"product": c.csvs,
+				},
+				directory: "/tmp/manifests",
+			}
+			err := cmd.run(context.TODO())
+			if err != nil && !c.expectError {
+				t.Fatalf("unexpected error %v", err)
+			}
+			if err == nil && c.expectError {
+				t.Fatal("error expected but got nil")
+			}
+		})
+	}
+}

--- a/pkg/utils/csv_test.go
+++ b/pkg/utils/csv_test.go
@@ -126,7 +126,7 @@ func TestGetPackageManifest(t *testing.T) {
 }
 
 func TestGetSortedCSVNames(t *testing.T) {
-	sortedcsvs := []csvName{
+	sortedcsvs := []CSVName{
 		{
 			Name: "3scale-operator.v0.4.0",
 			Version: semver.Version{
@@ -150,7 +150,7 @@ func TestGetSortedCSVNames(t *testing.T) {
 	tests := []struct {
 		name    string
 		args    args
-		want    csvNames
+		want    CSVNames
 		wantErr bool
 	}{
 		{


### PR DESCRIPTION
https://issues.redhat.com/browse/DEL-345

To verify:

* checkout the branch and build the cli
* run the following command
   ```
   ./delorean ews check-olm-graph -d <manifest dir>
   ```
    You should use the manifest directory in the integreatly-operator (https://github.com/integr8ly/integreatly-operator/tree/master/manifests). The checks should fail because the graph in `integreatly-monitoring` is broken. 