### PR TITLE
fix for pagerduty and deadmanssnitch secrets

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -148,9 +148,9 @@ install_rhmi() {
             --from-literal=port=587 \
             --from-literal=tls=true
     fi
-    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" create secret generic redhat-rhmi-pagerduty -n ${RHMI_OPERATOR_NAMESPACE} \
+    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" apply secret generic redhat-rhmi-pagerduty -n ${RHMI_OPERATOR_NAMESPACE} \
         --from-literal=serviceKey=dummykey
-    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" create secret generic redhat-rhmi-deadmanssnitch -n ${RHMI_OPERATOR_NAMESPACE} \
+    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" apply secret generic redhat-rhmi-deadmanssnitch -n ${RHMI_OPERATOR_NAMESPACE} \
         --from-literal=url=https://dms.example.com
 
     if [[ "${PATCH_CR_AWS_CM}" == true ]]; then


### PR DESCRIPTION
Currently in staging pagerduty secret is created by hive, so the `oc` command to create the secret fails. This change makes sure that commands to create the monitoring secrets won't fail if already created by hive.

https://issues.redhat.com/browse/INTLY-9551