### PR TITLE
DEL-357: Add verify-csv-version cmd

### DIFF
--- a/cmd/verifyVersion.go
+++ b/cmd/verifyVersion.go
@@ -49,7 +49,7 @@ func doVerifyVersion(flags *verifyVersionFlags) error {
 		return err
 	}
 
-	fmt.Printf("comparing incoming CSV version %s with current version %s", incoming, current)
+	fmt.Printf("comparing incoming CSV version %s with current version %s\n", incoming, current)
 	o := incoming.Compare(current)
 	switch o {
 	case -1:

--- a/cmd/verifyVersion.go
+++ b/cmd/verifyVersion.go
@@ -1,0 +1,69 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/blang/semver"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type verifyVersionFlags struct {
+	incomingManifests string
+	currentManifests  string
+}
+
+func init() {
+
+	flags := &verifyVersionFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "verify-csv-version",
+		Short: "Compare the incoming CSV version from the incoming manifests dir with the current CSV version",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := doVerifyVersion(flags)
+			if err != nil {
+				handleError(err)
+			}
+		},
+	}
+
+	ewsCmd.AddCommand(cmd)
+
+	cmd.Flags().StringVar(&flags.currentManifests, "incoming-manifests", "", "the manifests directory with the incoming CSV that must be bigger or equal then the current CSV")
+	cmd.MarkFlagRequired("incoming-manifests")
+
+	cmd.Flags().StringVarP(&flags.incomingManifests, "current-manifests", "o", "", "the manifests directory with the current CSV")
+	cmd.MarkFlagRequired("current-manifests")
+}
+
+func doVerifyVersion(flags *verifyVersionFlags) error {
+
+	incoming, err := getCurrentVersion(flags.incomingManifests)
+	if err != nil {
+		return err
+	}
+
+	current, err := getCurrentVersion(flags.currentManifests)
+	if err != nil {
+		return err
+	}
+
+	o := incoming.Compare(current)
+	switch o {
+	case -1:
+		return fmt.Errorf("the incoming operator version '%s' is smaller than current version '%s'", incoming, current)
+	case 0, 1:
+		return nil
+	}
+	return fmt.Errorf("unexpected compare result: %d", o)
+}
+
+func getCurrentVersion(manifests string) (semver.Version, error) {
+	csv, _, err := utils.GetCurrentCSV(manifests)
+	if err != nil {
+		return semver.Version{}, err
+	}
+
+	return csv.GetVersion()
+}

--- a/cmd/verifyVersion.go
+++ b/cmd/verifyVersion.go
@@ -30,10 +30,10 @@ func init() {
 
 	ewsCmd.AddCommand(cmd)
 
-	cmd.Flags().StringVar(&flags.currentManifests, "incoming-manifests", "", "the manifests directory with the incoming CSV that must be bigger or equal then the current CSV")
+	cmd.Flags().StringVar(&flags.incomingManifests, "incoming-manifests", "", "the manifests directory with the incoming CSV that must be bigger or equal then the current CSV")
 	cmd.MarkFlagRequired("incoming-manifests")
 
-	cmd.Flags().StringVarP(&flags.incomingManifests, "current-manifests", "o", "", "the manifests directory with the current CSV")
+	cmd.Flags().StringVar(&flags.currentManifests, "current-manifests", "", "the manifests directory with the current CSV")
 	cmd.MarkFlagRequired("current-manifests")
 }
 
@@ -49,6 +49,7 @@ func doVerifyVersion(flags *verifyVersionFlags) error {
 		return err
 	}
 
+	fmt.Printf("comparing incoming CSV version %s with current version %s", incoming, current)
 	o := incoming.Compare(current)
 	switch o {
 	case -1:

--- a/cmd/verifyVersion_test.go
+++ b/cmd/verifyVersion_test.go
@@ -1,0 +1,46 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestVerifyVersion(t *testing.T) {
+	tests := []struct {
+		name    string
+		flags   *verifyVersionFlags
+		wantErr bool
+	}{
+		{
+			name: "test new incoming CSV with old current CSV",
+			flags: &verifyVersionFlags{
+				incomingManifests: "../pkg/utils/testdata/validManifests/3scale3",
+				currentManifests:  "../pkg/utils/testdata/validManifests/3scale2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test equal incoming CSV with current CSV",
+			flags: &verifyVersionFlags{
+				incomingManifests: "../pkg/utils/testdata/validManifests/3scale",
+				currentManifests:  "../pkg/utils/testdata/validManifests/3scale",
+			},
+			wantErr: false,
+		},
+		{
+			name: "test old incoming CSV with newer current CSV",
+			flags: &verifyVersionFlags{
+				incomingManifests: "../pkg/utils/testdata/validManifests/3scale",
+				currentManifests:  "../pkg/utils/testdata/validManifests/3scale2",
+			},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+
+			if err := doVerifyVersion(tt.flags); (err != nil) != tt.wantErr {
+				t.Errorf("doVerifyVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What**

This cmd will verify that the incoming operator version is not smaller than the version already on the integreatly-operator

**Try it**:

* you need to clone the integreatly-operator
* need to compile the Delorean cli

```
mkdir /tmp/3scale
./delorean ews extract-manifests --src-image "registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-3scale-rhel7-operator-metadata:1.11.0-68" --extract-dir /tmp/3scale
./delorean ews verify-csv-version --incoming-manifests /tmp/3scale --current-manifests ../integreatly-operator/manifests/integreatly-3scale
```

the script should fail