### PR TITLE
Removal of pagerduty secret creation

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -148,9 +148,10 @@ install_rhmi() {
             --from-literal=port=587 \
             --from-literal=tls=true
     fi
-    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" apply secret generic redhat-rhmi-pagerduty -n ${RHMI_OPERATOR_NAMESPACE} \
+    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" get secret redhat-rhmi-pagerduty -n ${RHMI_OPERATOR_NAMESPACE} \
+        || oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" create secret generic redhat-rhmi-pagerduty -n ${RHMI_OPERATOR_NAMESPACE} \
         --from-literal=serviceKey=dummykey
-    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" apply secret generic redhat-rhmi-deadmanssnitch -n ${RHMI_OPERATOR_NAMESPACE} \
+    oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" create secret generic redhat-rhmi-deadmanssnitch -n ${RHMI_OPERATOR_NAMESPACE} \
         --from-literal=url=https://dms.example.com
 
     if [[ "${PATCH_CR_AWS_CM}" == true ]]; then


### PR DESCRIPTION
Fix for INTLY-9551

The Hive now creates the pagerduty secret, so it should not be created by the pipeline.

Also fixed bug in dms secret creation: `oc apply` does not have `--from-literal` flag, the `oc create` has to be used. This is basically a revert of https://github.com/integr8ly/delorean/commit/a658d684aba6b9cdb2a50042180df798a0521ecc