### PR TITLE
add set-product-version command

### DIFF
--- a/cmd/manageRHMITypes.go
+++ b/cmd/manageRHMITypes.go
@@ -1,0 +1,126 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
+	"io/ioutil"
+	"os"
+	"regexp"
+	"strings"
+)
+
+type manageTypesCmdOptions struct {
+	directory string
+	product   string
+	version   string
+}
+
+func init() {
+
+	flags := &manageTypesCmdOptions{}
+
+	cmd := &cobra.Command{
+		Use:   "set-product-version",
+		Short: "Sets the operator and product version for a product in the rhmi_types file",
+		Run: func(cmd *cobra.Command, args []string) {
+			err := SetVersion(flags.directory, flags.product, flags.version)
+			if err != nil {
+				handleError(err)
+			}
+		},
+	}
+
+	ewsCmd.AddCommand(cmd)
+
+	cmd.Flags().StringVarP(&flags.directory, "directory", "d", "", "Path to rhmi_types file")
+	cmd.MarkFlagRequired("directory")
+
+	cmd.Flags().StringVarP(&flags.product, "product", "p", "", "The product name")
+	cmd.MarkFlagRequired("product")
+
+	cmd.Flags().StringVarP(&flags.version, "version", "v", "", "The desired version")
+	cmd.MarkFlagRequired("version")
+}
+
+func SetVersion(directory string, product string, version string) error {
+	product = PrepareProductName(product)
+	fmt.Println(fmt.Sprintf("setting version of product %s to %s", product, version))
+	read, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	bytes, err := ioutil.ReadAll(read)
+	if err != nil {
+		return err
+	}
+	out := ParseVersion(bytes, product, version)
+	fmt.Println(fmt.Sprintf("writing changes to rhmi_types file at %s ", directory))
+	err = ioutil.WriteFile(directory, []byte(out), 600)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func PrepareProductName(product string) string {
+	switch product {
+	case "3scale":
+		product = "3Scale"
+	case "amq-online":
+		product = "AMQOnline"
+	case "amq-streams":
+		product = "AMQStreams"
+	case "apicurito":
+		product = "Apicurito"
+	case "codeready-workspaces":
+		product = "CodeReadyWorkspaces"
+	case "fuse-online":
+		product = "FuseOnline"
+	case "rhsso":
+		product = "RHSSO"
+	}
+
+	return product
+}
+
+func ParseVersion(in []byte, product string, version string) string {
+	// remove whitespace and "'s
+	version = strings.ReplaceAll(version, "\"", "")
+	version = strings.TrimSpace(version)
+
+	var ReOperatorVersion = regexp.MustCompile(`OperatorVersion` + product + `.*`)
+	var ReProductVersion = regexp.MustCompile(`Version` + product + `.*`)
+
+	operatorVersion := ReOperatorVersion.FindString(string(in))
+	productVersion := ReProductVersion.FindString(string(in))
+
+	// remove whitespace and "'s
+	ovs := strings.Split(operatorVersion, "=")[1]
+	ovs = strings.ReplaceAll(ovs, "\"", "")
+	ovs = strings.TrimSpace(ovs)
+
+	pvs := strings.Split(productVersion, "=")[1]
+
+	currentOperatorMajor := semver.Major("v" + ovs)
+	newOperatorMajor := semver.Major("v" + version)
+
+	var out string
+	// we only want to set the Version<product> var to CHANGEME for minor releases
+	fmt.Println(fmt.Sprintf("current OperatorVersion: %s Found OperatorVersion: %s", currentOperatorMajor, newOperatorMajor))
+	c := semver.Compare(currentOperatorMajor, newOperatorMajor)
+	// major versions are a match
+	if c == 0 {
+		out = strings.Replace(string(in), pvs, " \"CHANGEME\"", 1)
+		r := strings.Replace(operatorVersion, ovs, version, 1)
+		out = strings.Replace(out, operatorVersion, r, 1)
+	}
+
+	// if it's not a minor release only change the OperatorVersion<product> var
+	// if the version is 0.x.x then semver returns empty string so account for it
+	if c != 0 || currentOperatorMajor == "" && newOperatorMajor == "" {
+		out = strings.Replace(string(in), ovs, version, 1)
+	}
+
+	return out
+}

--- a/cmd/manageRHMITypes.go
+++ b/cmd/manageRHMITypes.go
@@ -12,8 +12,8 @@ import (
 
 type manageTypesCmdOptions struct {
 	filepath string
-	product   string
-	version   string
+	product  string
+	version  string
 }
 
 func init() {
@@ -21,8 +21,8 @@ func init() {
 	flags := &manageTypesCmdOptions{}
 
 	cmd := &cobra.Command{
-		Use:   "set-product-version",
-		Short: "Sets the operator and product version for a product in the rhmi_types file",
+		Use:   "set-product-operator-version",
+		Short: "Sets the operator version for a product in the rhmi_types file and sets product to CHANGEME if a minor version update",
 		Run: func(cmd *cobra.Command, args []string) {
 			err := SetVersion(flags.filepath, flags.product, flags.version)
 			if err != nil {
@@ -45,7 +45,7 @@ func init() {
 
 func SetVersion(filepath string, product string, version string) error {
 	product = PrepareProductName(product)
-	fmt.Println(fmt.Sprintf("setting version of product %s to %s", product, version))
+	fmt.Println(fmt.Sprintf("setting version of product operator %s to %s", product, version))
 	read, err := os.Open(filepath)
 	if err != nil {
 		return err

--- a/cmd/manageRHMITypes.go
+++ b/cmd/manageRHMITypes.go
@@ -11,7 +11,7 @@ import (
 )
 
 type manageTypesCmdOptions struct {
-	directory string
+	filepath string
 	product   string
 	version   string
 }
@@ -24,7 +24,7 @@ func init() {
 		Use:   "set-product-version",
 		Short: "Sets the operator and product version for a product in the rhmi_types file",
 		Run: func(cmd *cobra.Command, args []string) {
-			err := SetVersion(flags.directory, flags.product, flags.version)
+			err := SetVersion(flags.filepath, flags.product, flags.version)
 			if err != nil {
 				handleError(err)
 			}
@@ -33,8 +33,8 @@ func init() {
 
 	ewsCmd.AddCommand(cmd)
 
-	cmd.Flags().StringVarP(&flags.directory, "directory", "d", "", "Path to rhmi_types file")
-	cmd.MarkFlagRequired("directory")
+	cmd.Flags().StringVarP(&flags.filepath, "filepath", "f", "", "Path to rhmi_types file")
+	cmd.MarkFlagRequired("filepath")
 
 	cmd.Flags().StringVarP(&flags.product, "product", "p", "", "The product name")
 	cmd.MarkFlagRequired("product")
@@ -43,10 +43,10 @@ func init() {
 	cmd.MarkFlagRequired("version")
 }
 
-func SetVersion(directory string, product string, version string) error {
+func SetVersion(filepath string, product string, version string) error {
 	product = PrepareProductName(product)
 	fmt.Println(fmt.Sprintf("setting version of product %s to %s", product, version))
-	read, err := os.Open(directory)
+	read, err := os.Open(filepath)
 	if err != nil {
 		return err
 	}
@@ -55,8 +55,8 @@ func SetVersion(directory string, product string, version string) error {
 		return err
 	}
 	out := ParseVersion(bytes, product, version)
-	fmt.Println(fmt.Sprintf("writing changes to rhmi_types file at %s ", directory))
-	err = ioutil.WriteFile(directory, []byte(out), 600)
+	fmt.Println(fmt.Sprintf("writing changes to rhmi_types file at %s ", filepath))
+	err = ioutil.WriteFile(filepath, []byte(out), 600)
 	if err != nil {
 		return err
 	}

--- a/cmd/manageRHMITypes_test.go
+++ b/cmd/manageRHMITypes_test.go
@@ -138,17 +138,11 @@ func verifyTypesFile(t *testing.T, filepath, product string, version string, maj
 		if ovs != version {
 			t.Errorf("error found incorrect version string, wanted = %s, got %s", ovs, version)
 		}
-		if pvs == "CHANGEME" {
-			t.Errorf("error found incorrect version string got %s", pvs)
-		}
 	}
 
 	if majmin == "minor" {
 		if ovs != version {
 			t.Errorf("error found incorrect version string, wanted = %s, got %s", ovs, version)
-		}
-		if pvs != "CHANGEME" {
-			t.Errorf("error found incorrect version string, wanted = CHANGEME got %s", pvs)
 		}
 	}
 

--- a/cmd/manageRHMITypes_test.go
+++ b/cmd/manageRHMITypes_test.go
@@ -1,0 +1,157 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"io/ioutil"
+	"os"
+	"path"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestManageRHMITypes(t *testing.T) {
+	type args struct {
+		ctx     context.Context
+		cmdOpts *manageTypesCmdOptions
+	}
+	tests := []struct {
+		name    string
+		args    args
+		verify  func(t *testing.T, directory string, product string, version string, majmin string) error
+		wantErr bool
+		majmin  string
+	}{
+		{
+			name: "test setting 3scale major version",
+			args: args{context.TODO(), &manageTypesCmdOptions{
+				directory: "",
+				product:   "3scale",
+				version:   "9.9.9",
+			}},
+			wantErr: false,
+			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {
+				return verifyTypesFile(t, directory, product, version, "")
+			},
+			majmin: "major",
+		},
+		{
+			name: "test setting amq-online major version",
+			args: args{context.TODO(), &manageTypesCmdOptions{
+				directory: "",
+				product:   "amq-online",
+				version:   "9.9.9",
+			}},
+			wantErr: false,
+			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {
+				return verifyTypesFile(t, directory, product, version, "")
+			},
+			majmin: "major",
+		},
+		{
+			name: "test setting 3scale minor version",
+			args: args{context.TODO(), &manageTypesCmdOptions{
+				directory: "",
+				product:   "3scale",
+				version:   "9.10.0",
+			}},
+			wantErr: false,
+			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {
+				return verifyTypesFile(t, directory, product, version, "")
+			},
+			majmin: "minor",
+		},
+		{
+			name: "test setting amq-online minor version",
+			args: args{context.TODO(), &manageTypesCmdOptions{
+				directory: "",
+				product:   "amq-online",
+				version:   "9.10.0",
+			}},
+			wantErr: false,
+			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {
+				return verifyTypesFile(t, directory, product, version, "")
+			},
+			majmin: "minor",
+		},
+	}
+	for _, tt := range tests {
+		testDir, err := ioutil.TempDir(os.TempDir(), "test-")
+		if err != nil {
+			t.Fatal(err)
+		}
+		err = utils.CopyDirectory("./testdata/manageRHMITypes", testDir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		tt.args.cmdOpts.directory = path.Join(testDir, "rhmi_types")
+		t.Run(tt.name, func(t *testing.T) {
+			if err := SetVersion(tt.args.cmdOpts.directory, tt.args.cmdOpts.product, tt.args.cmdOpts.version); (err != nil) != tt.wantErr {
+				t.Errorf("SetVersion() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if !tt.wantErr {
+				if tt.verify != nil {
+					if err := tt.verify(t, tt.args.cmdOpts.directory, tt.args.cmdOpts.product, tt.args.cmdOpts.version, tt.majmin); err != nil {
+						fmt.Println("d: ", tt.args.cmdOpts.directory)
+						t.Fatalf("verification failed due to error: %v", err)
+					}
+				}
+			}
+
+			err = os.RemoveAll(testDir)
+			if err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func verifyTypesFile(t *testing.T, directory, product string, version string, majmin string) (error) {
+	f, err := os.Open(directory)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	bytes, _ := ioutil.ReadAll(f)
+	product = PrepareProductName(product)
+
+	var ReOperatorVersion = regexp.MustCompile(`OperatorVersion` + product + `.*`)
+	var ReProductVersion = regexp.MustCompile(`Version` + product + `.*`)
+
+	operatorVersion := ReOperatorVersion.FindString(string(bytes))
+	productVersion := ReProductVersion.FindString(string(bytes))
+
+	// Remove the "'s so it can validate against the version
+	ovs := strings.Split(operatorVersion, "=")[1]
+	ovs = strings.ReplaceAll(ovs, "\"", "")
+	ovs = strings.TrimSpace(ovs)
+
+	pvs := strings.Split(productVersion, "=")[1]
+	pvs = strings.ReplaceAll(pvs, "\"", "")
+	pvs = strings.TrimSpace(pvs)
+
+	if majmin == "major" {
+		if ovs != version {
+			t.Errorf("error found incorrect version string, wanted = %s, got %s", ovs, version)
+		}
+		if pvs == "CHANGEME" {
+			t.Errorf("error found incorrect version string got %s", pvs)
+		}
+	}
+
+	if majmin == "minor" {
+		if ovs != version {
+			t.Errorf("error found incorrect version string, wanted = %s, got %s", ovs, version)
+		}
+		if pvs != "CHANGEME" {
+			t.Errorf("error found incorrect version string, wanted = CHANGEME got %s", pvs)
+		}
+	}
+
+
+	return nil
+}

--- a/cmd/manageRHMITypes_test.go
+++ b/cmd/manageRHMITypes_test.go
@@ -109,7 +109,7 @@ func TestManageRHMITypes(t *testing.T) {
 	}
 }
 
-func verifyTypesFile(t *testing.T, directory, product string, version string, majmin string) (error) {
+func verifyTypesFile(t *testing.T, directory, product string, version string, majmin string) error {
 	f, err := os.Open(directory)
 	if err != nil {
 		return err
@@ -151,7 +151,6 @@ func verifyTypesFile(t *testing.T, directory, product string, version string, ma
 			t.Errorf("error found incorrect version string, wanted = CHANGEME got %s", pvs)
 		}
 	}
-
 
 	return nil
 }

--- a/cmd/manageRHMITypes_test.go
+++ b/cmd/manageRHMITypes_test.go
@@ -28,8 +28,8 @@ func TestManageRHMITypes(t *testing.T) {
 			name: "test setting 3scale major version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
 				filepath: "",
-				product:   "3scale",
-				version:   "9.9.9",
+				product:  "3scale",
+				version:  "9.9.9",
 			}},
 			wantErr: false,
 			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {
@@ -41,8 +41,8 @@ func TestManageRHMITypes(t *testing.T) {
 			name: "test setting amq-online major version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
 				filepath: "",
-				product:   "amq-online",
-				version:   "9.9.9",
+				product:  "amq-online",
+				version:  "9.9.9",
 			}},
 			wantErr: false,
 			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {
@@ -54,8 +54,8 @@ func TestManageRHMITypes(t *testing.T) {
 			name: "test setting 3scale minor version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
 				filepath: "",
-				product:   "3scale",
-				version:   "9.10.0",
+				product:  "3scale",
+				version:  "9.10.0",
 			}},
 			wantErr: false,
 			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {
@@ -67,8 +67,8 @@ func TestManageRHMITypes(t *testing.T) {
 			name: "test setting amq-online minor version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
 				filepath: "",
-				product:   "amq-online",
-				version:   "9.10.0",
+				product:  "amq-online",
+				version:  "9.10.0",
 			}},
 			wantErr: false,
 			verify: func(t *testing.T, directory string, product string, version string, majmin string) error {

--- a/cmd/manageRHMITypes_test.go
+++ b/cmd/manageRHMITypes_test.go
@@ -27,7 +27,7 @@ func TestManageRHMITypes(t *testing.T) {
 		{
 			name: "test setting 3scale major version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
-				directory: "",
+				filepath: "",
 				product:   "3scale",
 				version:   "9.9.9",
 			}},
@@ -40,7 +40,7 @@ func TestManageRHMITypes(t *testing.T) {
 		{
 			name: "test setting amq-online major version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
-				directory: "",
+				filepath: "",
 				product:   "amq-online",
 				version:   "9.9.9",
 			}},
@@ -53,7 +53,7 @@ func TestManageRHMITypes(t *testing.T) {
 		{
 			name: "test setting 3scale minor version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
-				directory: "",
+				filepath: "",
 				product:   "3scale",
 				version:   "9.10.0",
 			}},
@@ -66,7 +66,7 @@ func TestManageRHMITypes(t *testing.T) {
 		{
 			name: "test setting amq-online minor version",
 			args: args{context.TODO(), &manageTypesCmdOptions{
-				directory: "",
+				filepath: "",
 				product:   "amq-online",
 				version:   "9.10.0",
 			}},
@@ -86,16 +86,16 @@ func TestManageRHMITypes(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		tt.args.cmdOpts.directory = path.Join(testDir, "rhmi_types")
+		tt.args.cmdOpts.filepath = path.Join(testDir, "rhmi_types")
 		t.Run(tt.name, func(t *testing.T) {
-			if err := SetVersion(tt.args.cmdOpts.directory, tt.args.cmdOpts.product, tt.args.cmdOpts.version); (err != nil) != tt.wantErr {
+			if err := SetVersion(tt.args.cmdOpts.filepath, tt.args.cmdOpts.product, tt.args.cmdOpts.version); (err != nil) != tt.wantErr {
 				t.Errorf("SetVersion() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
 			if !tt.wantErr {
 				if tt.verify != nil {
-					if err := tt.verify(t, tt.args.cmdOpts.directory, tt.args.cmdOpts.product, tt.args.cmdOpts.version, tt.majmin); err != nil {
-						fmt.Println("d: ", tt.args.cmdOpts.directory)
+					if err := tt.verify(t, tt.args.cmdOpts.filepath, tt.args.cmdOpts.product, tt.args.cmdOpts.version, tt.majmin); err != nil {
+						fmt.Println("d: ", tt.args.cmdOpts.filepath)
 						t.Fatalf("verification failed due to error: %v", err)
 					}
 				}
@@ -109,8 +109,8 @@ func TestManageRHMITypes(t *testing.T) {
 	}
 }
 
-func verifyTypesFile(t *testing.T, directory, product string, version string, majmin string) error {
-	f, err := os.Open(directory)
+func verifyTypesFile(t *testing.T, filepath, product string, version string, majmin string) error {
+	f, err := os.Open(filepath)
 	if err != nil {
 		return err
 	}

--- a/cmd/testdata/manageRHMITypes/rhmi_types
+++ b/cmd/testdata/manageRHMITypes/rhmi_types
@@ -1,0 +1,244 @@
+package v1alpha1
+
+import (
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+type StatusPhase string
+type InstallationType string
+type ProductName string
+type ProductVersion string
+type OperatorVersion string
+type PreflightStatus string
+type StageName string
+
+var (
+	PhaseNone                   StatusPhase = ""
+	PhaseAccepted               StatusPhase = "accepted"
+	PhaseCreatingSubscription   StatusPhase = "creating subscription"
+	PhaseAwaitingOperator       StatusPhase = "awaiting operator"
+	PhaseAwaitingCloudResources StatusPhase = "awaiting cloud resources"
+	PhaseCreatingComponents     StatusPhase = "creating components"
+	PhaseAwaitingComponents     StatusPhase = "awaiting components"
+
+	PhaseInProgress StatusPhase = "in progress"
+	PhaseCompleted  StatusPhase = "completed"
+	PhaseFailed     StatusPhase = "failed"
+
+	InstallationTypeWorkshop    InstallationType = "workshop"
+	InstallationTypeManaged     InstallationType = "managed"
+	InstallationTypeSelfManaged InstallationType = "self-managed"
+
+	BootstrapStage           StageName = "bootstrap"
+	CloudResourcesStage      StageName = "cloud-resources"
+	MonitoringStage          StageName = "monitoring"
+	AuthenticationStage      StageName = "authentication"
+	ProductsStage            StageName = "products"
+	SolutionExplorerStage    StageName = "solution-explorer"
+	UninstallProductsStage   StageName = "uninstall - products"
+	UninstallMonitoringStage StageName = "uninstall - monitoring"
+
+	ProductAMQStreams          ProductName = "amqstreams"
+	ProductAMQOnline           ProductName = "amqonline"
+	ProductSolutionExplorer    ProductName = "solution-explorer"
+	ProductRHSSO               ProductName = "rhsso"
+	ProductRHSSOUser           ProductName = "rhssouser"
+	ProductCodeReadyWorkspaces ProductName = "codeready-workspaces"
+	ProductFuse                ProductName = "fuse"
+	ProductFuseOnOpenshift     ProductName = "fuse-on-openshift"
+	Product3Scale              ProductName = "3scale"
+	ProductUps                 ProductName = "ups"
+	ProductApicurito           ProductName = "apicurito"
+	ProductMonitoring          ProductName = "middleware-monitoring"
+	ProductCloudResources      ProductName = "cloud-resources"
+	ProductDataSync            ProductName = "datasync"
+	ProductMonitoringSpec      ProductName = "monitoring-spec"
+
+	// Could not find a way to determine these versions dynamically, so they are hard-coded
+	// It is preferable to determine the version of a product dynamically (from a CR, or configmap, etc)
+	// Follow up Jira: https://issues.redhat.com/browse/INTLY-5946
+	VersionAMQOnline           ProductVersion = "1.4"
+	VersionApicurito           ProductVersion = "7.6"
+	VersionAMQStreams          ProductVersion = "1.1.0"
+	VersionCodeReadyWorkspaces ProductVersion = "2.1.1"
+	VersionFuseOnOpenshift     ProductVersion = "7.6"
+	VersionMonitoring          ProductVersion = "1.2.1"
+	Version3Scale              ProductVersion = "2.8"
+	VersionUps                 ProductVersion = "2.3.2"
+	VersionCloudResources      ProductVersion = "0.17.0"
+	VersionFuseOnline          ProductVersion = "7.6"
+	VersionDataSync            ProductVersion = "0.9.4"
+	VersionRHSSO               ProductVersion = "7.3"
+	VersionRHSSOUser           ProductVersion = "7.3"
+	VersionMonitoringSpec      ProductVersion = "1.0"
+	VersionSolutionExplorer    ProductVersion = "2.26.3"
+
+	// Versioning for Fuse on OpenShift does not follow a similar pattern to other products.
+	// It is currently implicitly tied to version 7.6 of Fuse, hence the 7.6 value for VersionFuseOnOpenshift above
+	// The need for the below tag references is due to the nature of installing which is documented here: (for 7.6)
+	// https://access.redhat.com/documentation/en-us/red_hat_fuse/7.6/html-single/fuse_on_openshift_guide/index#install-fuse-on-openshift4
+	TagFuseOnOpenShiftCore        string = "application-templates-2.1.0.fuse-760043-redhat-00001"
+	TagFuseOnOpenShiftSpringBoot2 string = "application-templates-2.1.0.fuse-sb2-760039-redhat-00001"
+
+	PreflightInProgress PreflightStatus = ""
+	PreflightSuccess    PreflightStatus = "successful"
+	PreflightFail       PreflightStatus = "failed"
+
+	// Operator image tags
+	OperatorVersionAMQStreams          OperatorVersion = "1.1.0"
+	OperatorVersionAMQOnline           OperatorVersion = "1.4"
+	OperatorVersionMonitoring          OperatorVersion = "1.2.1"
+	OperatorVersionSolutionExplorer    OperatorVersion = "0.0.60"
+	OperatorVersionRHSSO               OperatorVersion = "9.0.2"
+	OperatorVersionRHSSOUser           OperatorVersion = "9.0.2"
+	OperatorVersionCodeReadyWorkspaces OperatorVersion = "2.1.1"
+	OperatorVersion3Scale              OperatorVersion = "0.5.4"
+	OperatorVersionFuse                OperatorVersion = "1.6.0"
+	OperatorVersionCloudResources      OperatorVersion = "0.17.0"
+	OperatorVersionUPS                 OperatorVersion = "0.5.0"
+	OperatorVersionApicurito           OperatorVersion = "1.6.0"
+	OperatorVersionMonitoringSpec      OperatorVersion = "1.0"
+
+	// Event reasons to be used when emitting events
+	EventProcessingError       string = "ProcessingError"
+	EventInstallationCompleted string = "InstallationCompleted"
+	EventPreflightCheckPassed  string = "PreflightCheckPassed"
+	EventUpgradeApproved       string = "UpgradeApproved"
+
+	DefaultOriginPullSecretName      = "samples-registry-credentials"
+	DefaultOriginPullSecretNamespace = "openshift"
+)
+
+// RHMISpec defines the desired state of Installation
+// +k8s:openapi-gen=true
+type RHMISpec struct {
+	// INSERT ADDITIONAL SPEC FIELDS - desired state of cluster
+	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
+	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	Type                 string         `json:"type"`
+	RoutingSubdomain     string         `json:"routingSubdomain,omitempty"`
+	MasterURL            string         `json:"masterURL,omitempty"`
+	NamespacePrefix      string         `json:"namespacePrefix"`
+	SelfSignedCerts      bool           `json:"selfSignedCerts,omitempty"`
+	PullSecret           PullSecretSpec `json:"pullSecret,omitempty"`
+	UseClusterStorage    string         `json:"useClusterStorage,omitempty"`
+	AlertingEmailAddress string         `json:"alertingEmailAddress,omitempty"`
+
+	// OperatorsInProductNamespace is a flag that decides if
+	// the product operators should be installed in the product
+	// namespace (when set to true) or in standalone namespace
+	// (when set to false, default). Standalone namespace will
+	// be used only for those operators that support it.
+	OperatorsInProductNamespace bool `json:"operatorsInProductNamespace,omitempty"`
+
+	// SMTPSecret is the name of a secret in the installation
+	// namespace containing SMTP connection details. The secret
+	// must contain the following fields:
+	//
+	// host
+	// port
+	// tls
+	// username
+	// password
+	SMTPSecret string `json:"smtpSecret,omitempty"`
+
+	// PagerDutySecret is the name of a secret in the
+	// installation namespace containing PagerDuty account
+	// details. The secret must contain the following fields:
+	//
+	// serviceKey
+	PagerDutySecret string `json:"pagerDutySecret,omitempty"`
+
+	// DeadMansSnitchSecret is the name of a secret in the
+	// installation namespace containing connection details
+	// for Dead Mans Snitch. The secret must contain the
+	// following fields:
+	//
+	// url
+	DeadMansSnitchSecret string `json:"deadMansSnitchSecret,omitempty"`
+}
+
+type PullSecretSpec struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace"`
+}
+
+// RHMIStatus defines the observed state of Installation
+// +k8s:openapi-gen=true
+type RHMIStatus struct {
+	// INSERT ADDITIONAL STATUS FIELDS - define observed state of cluster
+	// Important: Run "operator-sdk generate k8s" to regenerate code after modifying this file
+	// Add custom validation using kubebuilder tags: https://book.kubebuilder.io/beyond_basics/generating_crd.html
+	Stages             map[StageName]RHMIStageStatus `json:"stages"`
+	Stage              StageName                     `json:"stage"`
+	PreflightStatus    PreflightStatus               `json:"preflightStatus,omitempty"`
+	PreflightMessage   string                        `json:"preflightMessage,omitempty"`
+	LastError          string                        `json:"lastError"`
+	GitHubOAuthEnabled bool                          `json:"gitHubOAuthEnabled,omitempty"`
+	SMTPEnabled        bool                          `json:"smtpEnabled,omitempty"`
+	Version            string                        `json:"version,omitempty"`
+	ToVersion          string                        `json:"toVersion,omitempty"`
+}
+
+type RHMIStageStatus struct {
+	Name     StageName                         `json:"name"`
+	Phase    StatusPhase                       `json:"phase"`
+	Products map[ProductName]RHMIProductStatus `json:"products,omitempty"`
+}
+
+type RHMIProductStatus struct {
+	Name            ProductName     `json:"name"`
+	OperatorVersion OperatorVersion `json:"operator,omitempty"`
+	Version         ProductVersion  `json:"version"`
+	Host            string          `json:"host"`
+	Type            string          `json:"type,omitempty"`
+	Mobile          bool            `json:"mobile,omitempty"`
+	Status          StatusPhase     `json:"status"`
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// RHMI is the Schema for the RHMI API
+// +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
+// +kubebuilder:resource:path=rhmis,scope=Namespaced
+// +operator-sdk:gen-csv:customresourcedefinitions.displayName="RHMI Installation"
+type RHMI struct {
+	metav1.TypeMeta   `json:",inline"`
+	metav1.ObjectMeta `json:"metadata,omitempty"`
+
+	Spec   RHMISpec   `json:"spec,omitempty"`
+	Status RHMIStatus `json:"status,omitempty"`
+}
+
+func (i *RHMI) GetProductStatusObject(product ProductName) *RHMIProductStatus {
+	for _, stage := range i.Status.Stages {
+		if product, ok := stage.Products[product]; ok {
+			return &product
+		}
+	}
+	return &RHMIProductStatus{
+		Name: product,
+	}
+}
+
+func (i *RHMI) GetPullSecretSpec() *PullSecretSpec {
+	if i.Spec.PullSecret.Name != "" && i.Spec.PullSecret.Namespace != "" {
+		return &(i.Spec.PullSecret)
+	} else {
+		return &PullSecretSpec{Name: DefaultOriginPullSecretName, Namespace: DefaultOriginPullSecretNamespace}
+	}
+}
+
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
+
+// RHMIList contains a list of Installation
+type RHMIList struct {
+	metav1.TypeMeta `json:",inline"`
+	metav1.ListMeta `json:"metadata,omitempty"`
+	Items           []RHMI `json:"items"`
+}
+
+func init() {
+	SchemeBuilder.Register(&RHMI{}, &RHMIList{})
+}

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/xanzy/go-gitlab v0.31.0
 	github.com/yvasiyarov/gorelic v0.0.7 // indirect
 	github.com/yvasiyarov/newrelic_platform_go v0.0.0-20160601141957-9c099fbc30e9 // indirect
+	golang.org/x/mod v0.2.0
 	golang.org/x/oauth2 v0.0.0-20190604053449-0f29369cfe45
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	gopkg.in/yaml.v2 v2.2.8

--- a/vendor/golang.org/x/mod/LICENSE
+++ b/vendor/golang.org/x/mod/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/mod/PATENTS
+++ b/vendor/golang.org/x/mod/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/mod/semver/semver.go
+++ b/vendor/golang.org/x/mod/semver/semver.go
@@ -1,0 +1,388 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semver implements comparison of semantic version strings.
+// In this package, semantic version strings must begin with a leading "v",
+// as in "v1.0.0".
+//
+// The general form of a semantic version string accepted by this package is
+//
+//	vMAJOR[.MINOR[.PATCH[-PRERELEASE][+BUILD]]]
+//
+// where square brackets indicate optional parts of the syntax;
+// MAJOR, MINOR, and PATCH are decimal integers without extra leading zeros;
+// PRERELEASE and BUILD are each a series of non-empty dot-separated identifiers
+// using only alphanumeric characters and hyphens; and
+// all-numeric PRERELEASE identifiers must not have leading zeros.
+//
+// This package follows Semantic Versioning 2.0.0 (see semver.org)
+// with two exceptions. First, it requires the "v" prefix. Second, it recognizes
+// vMAJOR and vMAJOR.MINOR (with no prerelease or build suffixes)
+// as shorthands for vMAJOR.0.0 and vMAJOR.MINOR.0.
+package semver
+
+// parsed returns the parsed form of a semantic version string.
+type parsed struct {
+	major      string
+	minor      string
+	patch      string
+	short      string
+	prerelease string
+	build      string
+	err        string
+}
+
+// IsValid reports whether v is a valid semantic version string.
+func IsValid(v string) bool {
+	_, ok := parse(v)
+	return ok
+}
+
+// Canonical returns the canonical formatting of the semantic version v.
+// It fills in any missing .MINOR or .PATCH and discards build metadata.
+// Two semantic versions compare equal only if their canonical formattings
+// are identical strings.
+// The canonical invalid semantic version is the empty string.
+func Canonical(v string) string {
+	p, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	if p.build != "" {
+		return v[:len(v)-len(p.build)]
+	}
+	if p.short != "" {
+		return v + p.short
+	}
+	return v
+}
+
+// Major returns the major version prefix of the semantic version v.
+// For example, Major("v2.1.0") == "v2".
+// If v is an invalid semantic version string, Major returns the empty string.
+func Major(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return v[:1+len(pv.major)]
+}
+
+// MajorMinor returns the major.minor version prefix of the semantic version v.
+// For example, MajorMinor("v2.1.0") == "v2.1".
+// If v is an invalid semantic version string, MajorMinor returns the empty string.
+func MajorMinor(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	i := 1 + len(pv.major)
+	if j := i + 1 + len(pv.minor); j <= len(v) && v[i] == '.' && v[i+1:j] == pv.minor {
+		return v[:j]
+	}
+	return v[:i] + "." + pv.minor
+}
+
+// Prerelease returns the prerelease suffix of the semantic version v.
+// For example, Prerelease("v2.1.0-pre+meta") == "-pre".
+// If v is an invalid semantic version string, Prerelease returns the empty string.
+func Prerelease(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.prerelease
+}
+
+// Build returns the build suffix of the semantic version v.
+// For example, Build("v2.1.0+meta") == "+meta".
+// If v is an invalid semantic version string, Build returns the empty string.
+func Build(v string) string {
+	pv, ok := parse(v)
+	if !ok {
+		return ""
+	}
+	return pv.build
+}
+
+// Compare returns an integer comparing two versions according to
+// semantic version precedence.
+// The result will be 0 if v == w, -1 if v < w, or +1 if v > w.
+//
+// An invalid semantic version string is considered less than a valid one.
+// All invalid semantic version strings compare equal to each other.
+func Compare(v, w string) int {
+	pv, ok1 := parse(v)
+	pw, ok2 := parse(w)
+	if !ok1 && !ok2 {
+		return 0
+	}
+	if !ok1 {
+		return -1
+	}
+	if !ok2 {
+		return +1
+	}
+	if c := compareInt(pv.major, pw.major); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.minor, pw.minor); c != 0 {
+		return c
+	}
+	if c := compareInt(pv.patch, pw.patch); c != 0 {
+		return c
+	}
+	return comparePrerelease(pv.prerelease, pw.prerelease)
+}
+
+// Max canonicalizes its arguments and then returns the version string
+// that compares greater.
+func Max(v, w string) string {
+	v = Canonical(v)
+	w = Canonical(w)
+	if Compare(v, w) > 0 {
+		return v
+	}
+	return w
+}
+
+func parse(v string) (p parsed, ok bool) {
+	if v == "" || v[0] != 'v' {
+		p.err = "missing v prefix"
+		return
+	}
+	p.major, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad major version"
+		return
+	}
+	if v == "" {
+		p.minor = "0"
+		p.patch = "0"
+		p.short = ".0.0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad minor prefix"
+		ok = false
+		return
+	}
+	p.minor, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad minor version"
+		return
+	}
+	if v == "" {
+		p.patch = "0"
+		p.short = ".0"
+		return
+	}
+	if v[0] != '.' {
+		p.err = "bad patch prefix"
+		ok = false
+		return
+	}
+	p.patch, v, ok = parseInt(v[1:])
+	if !ok {
+		p.err = "bad patch version"
+		return
+	}
+	if len(v) > 0 && v[0] == '-' {
+		p.prerelease, v, ok = parsePrerelease(v)
+		if !ok {
+			p.err = "bad prerelease"
+			return
+		}
+	}
+	if len(v) > 0 && v[0] == '+' {
+		p.build, v, ok = parseBuild(v)
+		if !ok {
+			p.err = "bad build"
+			return
+		}
+	}
+	if v != "" {
+		p.err = "junk on end"
+		ok = false
+		return
+	}
+	ok = true
+	return
+}
+
+func parseInt(v string) (t, rest string, ok bool) {
+	if v == "" {
+		return
+	}
+	if v[0] < '0' || '9' < v[0] {
+		return
+	}
+	i := 1
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	if v[0] == '0' && i != 1 {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parsePrerelease(v string) (t, rest string, ok bool) {
+	// "A pre-release version MAY be denoted by appending a hyphen and
+	// a series of dot separated identifiers immediately following the patch version.
+	// Identifiers MUST comprise only ASCII alphanumerics and hyphen [0-9A-Za-z-].
+	// Identifiers MUST NOT be empty. Numeric identifiers MUST NOT include leading zeroes."
+	if v == "" || v[0] != '-' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) && v[i] != '+' {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i || isBadNum(v[start:i]) {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i || isBadNum(v[start:i]) {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func parseBuild(v string) (t, rest string, ok bool) {
+	if v == "" || v[0] != '+' {
+		return
+	}
+	i := 1
+	start := 1
+	for i < len(v) {
+		if !isIdentChar(v[i]) && v[i] != '.' {
+			return
+		}
+		if v[i] == '.' {
+			if start == i {
+				return
+			}
+			start = i + 1
+		}
+		i++
+	}
+	if start == i {
+		return
+	}
+	return v[:i], v[i:], true
+}
+
+func isIdentChar(c byte) bool {
+	return 'A' <= c && c <= 'Z' || 'a' <= c && c <= 'z' || '0' <= c && c <= '9' || c == '-'
+}
+
+func isBadNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v) && i > 1 && v[0] == '0'
+}
+
+func isNum(v string) bool {
+	i := 0
+	for i < len(v) && '0' <= v[i] && v[i] <= '9' {
+		i++
+	}
+	return i == len(v)
+}
+
+func compareInt(x, y string) int {
+	if x == y {
+		return 0
+	}
+	if len(x) < len(y) {
+		return -1
+	}
+	if len(x) > len(y) {
+		return +1
+	}
+	if x < y {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func comparePrerelease(x, y string) int {
+	// "When major, minor, and patch are equal, a pre-release version has
+	// lower precedence than a normal version.
+	// Example: 1.0.0-alpha < 1.0.0.
+	// Precedence for two pre-release versions with the same major, minor,
+	// and patch version MUST be determined by comparing each dot separated
+	// identifier from left to right until a difference is found as follows:
+	// identifiers consisting of only digits are compared numerically and
+	// identifiers with letters or hyphens are compared lexically in ASCII
+	// sort order. Numeric identifiers always have lower precedence than
+	// non-numeric identifiers. A larger set of pre-release fields has a
+	// higher precedence than a smaller set, if all of the preceding
+	// identifiers are equal.
+	// Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta <
+	// 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0."
+	if x == y {
+		return 0
+	}
+	if x == "" {
+		return +1
+	}
+	if y == "" {
+		return -1
+	}
+	for x != "" && y != "" {
+		x = x[1:] // skip - or .
+		y = y[1:] // skip - or .
+		var dx, dy string
+		dx, x = nextIdent(x)
+		dy, y = nextIdent(y)
+		if dx != dy {
+			ix := isNum(dx)
+			iy := isNum(dy)
+			if ix != iy {
+				if ix {
+					return -1
+				} else {
+					return +1
+				}
+			}
+			if ix {
+				if len(dx) < len(dy) {
+					return -1
+				}
+				if len(dx) > len(dy) {
+					return +1
+				}
+			}
+			if dx < dy {
+				return -1
+			} else {
+				return +1
+			}
+		}
+	}
+	if x == "" {
+		return -1
+	} else {
+		return +1
+	}
+}
+
+func nextIdent(x string) (dx, rest string) {
+	i := 0
+	for i < len(x) && x[i] != '.' {
+		i++
+	}
+	return x[:i], x[i:]
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -275,6 +275,8 @@ golang.org/x/crypto/ssh/agent
 golang.org/x/crypto/ssh/internal/bcrypt_pbkdf
 golang.org/x/crypto/ssh/knownhosts
 golang.org/x/crypto/ssh/terminal
+# golang.org/x/mod v0.2.0
+golang.org/x/mod/semver
 # golang.org/x/net v0.0.0-20200301022130-244492dfa37a
 golang.org/x/net/context
 golang.org/x/net/context/ctxhttp


### PR DESCRIPTION
Adds set-product-version command to set the productVersion and operatorVersion in the rhmi_types file to either "CHANGEME" or the discovered operator version.

https://issues.redhat.com/browse/DEL-213

To Verify

1. Checkout this branch and build
2. Run `./delorean ews set-product-version -d cmd/testdata/manageRHMITypes/rhmi_types -p 3scale -v 9.9.9`
3. Verify that the `OperatorVersion3Scale` var has been changed to `9.9.9` and that the `Version3Scale` var has not been changed
4. Run `./delorean ews set-product-version -d cmd/testdata/manageRHMITypes/rhmi_types -p 3scale -v 9.10.0`
5. Verify that the `OperatorVersion3Scale` var has been changed to `9.10.0` and that the `Version3Scale` var has been changed to `CHANGEME`
