### PR TITLE
INTLY-9464: Add release tag-repository cmd

### DIFF
--- a/cmd/tagRepository.go
+++ b/cmd/tagRepository.go
@@ -1,0 +1,88 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/integr8ly/delorean/pkg/services"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+type tagRepositoryFlags struct {
+	organization   string
+	repository     string
+	branch         string
+	skipPreRelease bool
+}
+
+func init() {
+
+	flags := &tagRepositoryFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "tag-repository",
+		Short: "Tag the passed repository with the given release on the given branch",
+		Run: func(cmd *cobra.Command, args []string) {
+
+			ghToken, err := requireValue(GithubTokenKey)
+			if err != nil {
+				handleError(err)
+			}
+			ghClient := newGithubClient(ghToken)
+
+			version := releaseVersion
+			if version == "" {
+				handleError(errors.New("version is not defined"))
+			}
+
+			if err := runTagRepository(cmd.Context(), ghClient.Git, version, flags); err != nil {
+				handleError(err)
+			}
+		},
+	}
+
+	cmd.Flags().StringVar(&flags.organization, "organization", "", "GitHub organization where the repository reside")
+	cmd.Flags().StringVar(&flags.repository, "repository", "", "Repository in the GitHub organization on which to create the tag")
+	cmd.Flags().StringVar(&flags.branch, "branch", "master", "Branch to create the tag")
+	cmd.Flags().BoolVar(&flags.skipPreRelease, "skip-pre-release", false, "Don't tag te repository if the version is a pre-release")
+	cmd.MarkFlagRequired("organization")
+	cmd.MarkFlagRequired("repository")
+
+	releaseCmd.AddCommand(cmd)
+}
+
+func runTagRepository(ctx context.Context, ghClient services.GitService, version string, flags *tagRepositoryFlags) error {
+	v, err := utils.NewRHMIVersion(version)
+	if err != nil {
+		return err
+	}
+
+	if flags.skipPreRelease && v.IsPreRelease() {
+		fmt.Println("Skip pre-release version:", v)
+		return nil
+	}
+
+	repo := &githubRepoInfo{owner: flags.organization, repo: flags.repository}
+
+	branchRefName := plumbing.NewBranchReferenceName(flags.branch)
+	fmt.Println("Fetch git ref:", branchRefName)
+	headRef, err := getGitRef(ctx, ghClient, repo, branchRefName.String(), false)
+	if err != nil {
+		return err
+	}
+	if headRef == nil {
+		return fmt.Errorf("can not find git ref: %s", branchRefName)
+	}
+
+	fmt.Println("Create git tag:", v.TagName())
+	tagRef, err := createGitTag(ctx, ghClient, repo, v.TagName(), headRef.GetObject().GetSHA())
+	if err != nil {
+		return err
+	}
+	fmt.Println("Git tag", v.TagName(), "created:", tagRef.GetURL())
+
+	return nil
+}

--- a/cmd/tagRepository_test.go
+++ b/cmd/tagRepository_test.go
@@ -1,0 +1,125 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/google/go-github/v30/github"
+	"github.com/integr8ly/delorean/pkg/services"
+)
+
+func TestTagRepository(t *testing.T) {
+
+	masterRef := "refs/heads/master"
+	masterSha := "masterSha"
+
+	cases := []struct {
+		desc        string
+		ghClient    services.GitService
+		version     string
+		flags       *tagRepositoryFlags
+		expectError bool
+	}{
+		{
+			desc: "successfully tag the repository",
+			ghClient: &mockGitService{
+				getRefFunc: func(ctx context.Context, owner string, repo string, ref string) (reference []*github.Reference, response *github.Response, err error) {
+					if strings.Index(ref, "refs/heads/") > -1 {
+						return []*github.Reference{{
+							Ref: &masterRef,
+							Object: &github.GitObject{
+								SHA: &masterSha,
+							},
+						}}, nil, nil
+					}
+					return nil, nil, nil
+				},
+				createRefFunc: func(ctx context.Context, owner string, repo string, ref *github.Reference) (reference *github.Reference, response *github.Response, err error) {
+					return &github.Reference{
+						Object: &github.GitObject{
+							SHA: &masterSha,
+						},
+					}, nil, nil
+				},
+			},
+			version:     "2.0.0-rc1",
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: false},
+			expectError: false,
+		},
+		{
+			desc: "successfully tag repository with final version and skip-pre-release",
+			ghClient: &mockGitService{
+				getRefFunc: func(ctx context.Context, owner string, repo string, ref string) (reference []*github.Reference, response *github.Response, err error) {
+					if strings.Index(ref, "refs/heads/") > -1 {
+						return []*github.Reference{{
+							Ref: &masterRef,
+							Object: &github.GitObject{
+								SHA: &masterSha,
+							},
+						}}, nil, nil
+					}
+					return nil, nil, nil
+				},
+				createRefFunc: func(ctx context.Context, owner string, repo string, ref *github.Reference) (reference *github.Reference, response *github.Response, err error) {
+					return &github.Reference{
+						Object: &github.GitObject{
+							SHA: &masterSha,
+						},
+					}, nil, nil
+				},
+			},
+			version:     "2.0.0",
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: true},
+			expectError: false,
+		},
+		{
+			desc: "skip tag repository with pre-release version and skip-pre-release",
+			ghClient: &mockGitService{
+				getRefFunc: func(ctx context.Context, owner string, repo string, ref string) (reference []*github.Reference, response *github.Response, err error) {
+					return nil, nil, errors.New("unexpected call")
+				},
+				createRefFunc: func(ctx context.Context, owner string, repo string, ref *github.Reference) (reference *github.Reference, response *github.Response, err error) {
+					return nil, nil, errors.New("unexpected call")
+				},
+			},
+			version:     "2.0.0-rc1",
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: true},
+			expectError: false,
+		},
+		{
+			desc: "fail with tag already exists",
+			ghClient: &mockGitService{
+				getRefFunc: func(ctx context.Context, owner string, repo string, ref string) (reference []*github.Reference, response *github.Response, err error) {
+					if strings.Index(ref, "refs/heads/") > -1 {
+						return []*github.Reference{{
+							Ref: &masterRef,
+							Object: &github.GitObject{
+								SHA: &masterSha,
+							},
+						}}, nil, nil
+					}
+					return nil, nil, nil
+				},
+				createRefFunc: func(ctx context.Context, owner string, repo string, ref *github.Reference) (reference *github.Reference, response *github.Response, err error) {
+					return nil, nil, errors.New("tag already exists")
+				},
+			},
+			version:     "2.0.0-rc1",
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: false},
+			expectError: true,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.desc, func(t *testing.T) {
+			err := runTagRepository(context.TODO(), c.ghClient, c.version, c.flags)
+			if c.expectError && err == nil {
+				t.Errorf("error should not be nil")
+			} else if !c.expectError && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**What**

add the `release tag-repository` to tag any repo with the release version 

**Try it**

1. Run: `./delorean release tag-repository --branch master --organization YOUR_ORG --repository YOUR_REPO --version 2.9.0-rc1 --skip-pre-release`
   > The release tag should not be created
2. Run: `./delorean  release tag-repository --branch master --organization YOUR_ORG --repository YOUR_REPO --version 2.9.0-rc1`
   > The release tag for should be created on the repository
3. Run: `./delorean  release tag-repository --branch master --organization YOUR_ORG --repository YOUR_REPO --version 2.9.0 --skip-pre-release`
   > The release tag for should be created on the repository