### PR TITLE
Fix promotion of RC image to final release

### DIFF
--- a/cmd/tagRelease.go
+++ b/cmd/tagRelease.go
@@ -67,7 +67,7 @@ func DoTagRelease(ctx context.Context, ghClient services.GitService, gitRepoInfo
 		return err
 	}
 	fmt.Println("Fetch git ref:", fmt.Sprintf("refs/tags/%s", rv.TagName()))
-	existingTagRef, err := getGitRef(ctx, ghClient, gitRepoInfo, fmt.Sprintf("refs/tags/%s", rv.TagName()), true)
+	existingRCTagRef, err := getGitRef(ctx, ghClient, gitRepoInfo, fmt.Sprintf("refs/tags/%s", rv.RCTagRef()), true)
 	if err != nil {
 		return err
 	}
@@ -88,9 +88,9 @@ func DoTagRelease(ctx context.Context, ghClient services.GitService, gitRepoInfo
 		commitSHA := headRef.GetObject().GetSHA()
 
 		//If this is a final release and we have an existing tag (rc tag), promote the existing rc tag to the final release, otherwise continue as normal
-		if !rv.IsPreRelease() && existingTagRef != nil {
-			quaySrcTag = strings.Replace(existingTagRef.GetRef(), "refs/tags/", "", -1)
-			commitSHA = existingTagRef.GetObject().GetSHA()
+		if !rv.IsPreRelease() && existingRCTagRef != nil {
+			quaySrcTag = strings.Replace(existingRCTagRef.GetRef(), "refs/tags/", "", -1)
+			commitSHA = existingRCTagRef.GetObject().GetSHA()
 		}
 
 		ok := tryCreateQuayTag(ctx, quayClient, quayRepos, quaySrcTag, quayDstTag, commitSHA)

--- a/cmd/tagRelease_test.go
+++ b/cmd/tagRelease_test.go
@@ -72,6 +72,7 @@ func TestDoTagRelease(t *testing.T) {
 	tagShaRC2 := "tagShaRC2"
 	tagRefRC3 := "refs/tags/2.0.0-rc3"
 	tagShaRC3 := "tagShaRC3"
+	tagRefFinal := "refs/tags/2.0.0"
 
 	testTagName := "test"
 	testTagDigest := "testdigest"
@@ -170,6 +171,12 @@ func TestDoTagRelease(t *testing.T) {
 								Ref: &tagRefRC1,
 								Object: &github.GitObject{
 									SHA: &tagShaRC1,
+								},
+							},
+							{
+								Ref: &tagRefFinal,
+								Object: &github.GitObject{
+									SHA: &masterSha,
 								},
 							},
 						}, nil, nil

--- a/pkg/utils/rhmi_version.go
+++ b/pkg/utils/rhmi_version.go
@@ -61,6 +61,11 @@ func (v *RHMIVersion) TagName() string {
 	return fmt.Sprintf("v%s", v.String())
 }
 
+// RCTagRef returns a git ref that can be used to search for all RC Tags for this version
+func (v *RHMIVersion) RCTagRef() string {
+	return fmt.Sprintf("v%s-", v.MajorMinorPatch())
+}
+
 func (v *RHMIVersion) Base() string {
 	return v.base
 }


### PR DESCRIPTION
Ensure during the tag release command that we check for the latest RC tag ref and not just the latest tag when finding the git ref we need to promote the images during the final release creation.

Currently we run this command more than once, and the second time will always fail since the final release tag actually exists when getting the existing tags.

**Jira:**

https://issues.redhat.com/browse/DEL-369