### PR TITLE
prevent from erroring when smtp key deletion is attempted

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -161,7 +161,7 @@ delete_cluster() {
     # infra_id would be empty if the cluster was not fully provisioned
     if [[ -n "${SENDGRID_API_KEY:-}" ]] && [[ -n "${infra_id:-}" ]]; then
         echo "Deleting Sendgrid sub user and API key with ID: ${infra_id}"
-        smtp-service delete "${infra_id}"
+        smtp-service delete "${infra_id}" || true
     fi
 
     echo "Deleting the cluster with ID: ${cluster_id}"


### PR DESCRIPTION
## What
prevent from erroring when smtp key deletion is attempted - failed on nightly here: https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Nightly/job/rhmi-install-addon-flow/lastFailedBuild/console