### PR TITLE
refactor the osd-addon command to make it easier to extend to support…

### DIFF
--- a/configurations/managed-tenants-addons-config.yaml
+++ b/configurations/managed-tenants-addons-config.yaml
@@ -1,0 +1,31 @@
+---
+addons:
+  - name: "integreatly-operator"
+    csv:
+      repo: "https://github.com/integr8ly/integreatly-operator.git"
+      path: "deploy/olm-catalog/integreatly-operator"
+    channels:
+      - name: "stage"
+        directory: "integreatly-operator"
+        environment: "stage"
+        allow_pre_release: true
+      - name: "edge"
+        directory: "integreatly-operator-internal"
+        environment: "production"
+        allow_pre_release: false
+      - name: "stable"
+        directory: "integreatly-operator"
+        environment: "production"
+        allow_pre_release: false
+    override:
+      deployment:
+        name: "rhmi-operator"
+        container:
+          name: "rhmi-operator"
+          env_vars:
+            - name: "USE_CLUSTER_STORAGE"
+              value: ""
+            - name: "ALERTING_EMAIL_ADDRESS"
+              value: "{{ alertingEmailAddress }}"
+
+


### PR DESCRIPTION
… other addons

https://issues.redhat.com/browse/DEL-381

externalise all the addon-specific information into a configuration file. In the future, if we need to support another different addon, we can easily do that by updating the configuration file.

to verify:

* check out the branch and build it
* run the following command:
  ```
  ./delorean release osd-addon \
     --addons-config=./configurations/managed-tenants-addons-config.yaml \
     --channel=stable 
     --managed-tenants-origin=<your MT fork> \
     --managed-tenants-fork=<your MT fork> \
     --name=integreatly-operator \
     --version=2.6.0
  ```

Everything should still work as before