### PR TITLE
MGDAPI-5: Add make target to install Managed API addon

### DIFF
--- a/docs/ocm/README.md
+++ b/docs/ocm/README.md
@@ -1,4 +1,4 @@
-## Using `ocm` for installation of RHMI
+## Using `ocm` for installation of RHMI or Managed API Service
 
 If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using `ocm`. If you want to spin up a cluster using BYOC (your own AWS credentials), follow the additional steps marked as **BYOC**.
 
@@ -68,8 +68,11 @@ This command will send a request to [Red Hat OpenShift Cluster Manager](https://
 oc --config ocm/cluster.kubeconfig projects
 ```
 
-7. If you want to install the latest released RHMI, you can trigger it by applying an RHMI addon.
-Run `make ocm/install/rhmi-addon` to trigger the installation. Once the installation is completed, the installation CR with RHMI components info will be printed to the console.
+7. If you want to install the latest release, you can trigger it by applying an addon
+    1. For **RHMI**: Run `make ocm/install/rhmi-addon` to trigger the installation
+    2. For **Managed API Service**: Run `make ocm/install/managed-api-addon` to trigger the installaion
+  
+    Once the installation is completed, the installation CR with RHMI components info will be printed to the console
 
 8. If you want to delete your cluster, run `make ocm/cluster/delete`
 

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -40,6 +40,10 @@ ocm/cluster/create:
 ocm/install/rhmi-addon:
 	@${OCM_SH} install_rhmi
 
+.PHONY: ocm/install/managed-api-addon
+ocm/install/managed-api-addon:
+	@${OCM_SH} install_managed_api
+
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:
 	@${OCM_SH} delete_cluster


### PR DESCRIPTION
# Description

> Link to JIRA: https://issues.redhat.com/browse/MGDAPI-5

_Changes required for the Managed API addon pipeline: https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/merge_requests/307_

Add new `make ocm/install/managed-api-addon` target, it runs a new function in the
`ocm.sh` script that, similar to `ocm/install/rhmi-addon`, installs the addon in the
cluster and waits for the installation to finish, but uses the Managed API addon, and
relies on the products phase to decide when the installation was completed, as RHMI
relies on the Solution Explorer.

## Verification steps

1. Provision an OSD cluster and log into it
2. Save the cluster details into a file:
    ```sh
    ocm get /api/clusters_mgmt/v1/clusters/<CLUSTER ID> | jq -r  > ocm/cluster-details.json
    ```
3. Copy your kube config into the `ocm` folder
    ```sh
    # Replace "~/.kube/config" if you use a different location
    cp ~/.kube/config ocm/cluster.kubeconfig
    ```
4. Run the make target
    ```sh
    make ocm/install/managed-api-addon
    ```
5. Verify that the command works and the installation completes