### PR TITLE
MGDAPI-198: Created a downtime report for RHOAM

### DIFF
--- a/configurations/downtime-report-config-rhoam.yaml
+++ b/configurations/downtime-report-config-rhoam.yaml
@@ -1,0 +1,63 @@
+---
+# Update this configuration file to add more metrics. You can use the following params in the query:
+# "$range": the range of the query in milliseconds
+# "$duration": the range of the query in seconds. Can be used as the duration param in the query
+name: Downtime Report
+queries:
+  # 3scale related dowmtime metrics. For k8s endpoints, it assumes that the service is down when the kube_endpoint_address_available value is 0
+  - name: 3scale_apicast_production_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-production', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_apicast_staging_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-staging', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_system_developer_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-developer', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_system_master_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-master', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_system_memcache_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-memcache', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_system_provider_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-provider', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_system_sphinx_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-sphinx', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_zync_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_zync_database_provider_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync-database', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_backend_listener_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='backend-listener', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+  - name: 3scale_workload_app_downtime_seconds
+    type: query
+    query: "sum(workload_app_service_downtime_seconds{name='3scale_service'})"
+  # rhssouser related downtime metrics
+  - name: rhssouser_keycloak_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhmi-user-sso'} , 1)[$duration:30s]) * $range)/1000"
+  - name: rhssouser_keycloak_discovery_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhmi-user-sso'} , 1)[$duration:30s]) * $range)/1000"
+  - name: rhssouser_ui_blackbox_downtime_seconds
+    type: query
+    query: "$range - (probe_success{service='rhssouser-ui'} * $range)"
+  - name: rhssouser_workload_app_downtime_seconds
+    type: query
+    query: "sum(workload_app_service_downtime_seconds{name='sso_service'})"
+  # rhsso related downtime metrics
+  - name: rhsso_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhmi-sso'} , 1)[$duration:30s]) * $range)/1000"
+  - name: rhsso_keycloak_discovery_k8s_endpoint_downtime_seconds
+    type: query
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhmi-sso'} , 1)[$duration:30s]) * $range)/1000"
+  - name: rhsso_ui_blackbox_downtime_seconds
+    type: query
+    query: "$range - (probe_success{service='rhsso-ui'} * $range)"


### PR DESCRIPTION
## What
The delorean cli has a template for generating a downtime report for rhmi produce. We need one specifically for RHOAM products. 

## How 
Create a new template file for generating downtime for RHOAM products 

## Verification
- deploy Managed API cluster with Mutli AZ
- run and deploy the (workload-web-app)[https://github.com/integr8ly/workload-web-app] against the cluster
```bash
git clone https://github.com/integr8ly/workload-web-app
cd workload-web-app
make local/deploy
```
- clone this repo
- do a build for the delorean Cli
```bash
make build/cli
```
- cause some downtime by running the (disableAz.sh)[https://github.com/integr8ly/integreatly-operator/blob/master/scripts/disableAz.sh] script from the integreatly-operator
```
# e.g.
./disableAz.sh true eu-west-1a
# Wait about 30min and reinstate the AZ
./disableAz.sh false eu-west-1a
```

- run the command to generate a report for a RHOAM cluster
```bash
./delorean pipeline query-report --config-file ./configurations/downtime-report-config-rhoam.yaml -o ~
```
- Check the output of the report only has information on 3scale, user-sso and rhsso
e.g. 
```yaml
name: Downtime Report
results:
- name: 3scale_apicast_production_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-production',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: apicast-production
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796663e+09
    - "0"
  resultType: vector
- name: 3scale_apicast_staging_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-staging',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: apicast-staging
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796663e+09
    - "0"
  resultType: vector
- name: 3scale_system_developer_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-developer',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: system-developer
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796663e+09
    - "4140.000000000001"
  resultType: vector
- name: 3scale_system_master_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-master',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: system-master
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796663e+09
    - "4140.000000000001"
  resultType: vector
- name: 3scale_system_memcache_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-memcache',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: system-memcache
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796663e+09
    - "0"
  resultType: vector
- name: 3scale_system_provider_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-provider',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: system-provider
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796919e+09
    - "4140.000000000001"
  resultType: vector
- name: 3scale_system_sphinx_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-sphinx',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: system-sphinx
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796919e+09
    - "0"
  resultType: vector
- name: 3scale_zync_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: zync
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796919e+09
    - "0"
  resultType: vector
- name: 3scale_zync_database_provider_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync-database',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: zync-database
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796946e+09
    - "0"
  resultType: vector
- name: 3scale_backend_listener_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='backend-listener',
    namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: backend-listener
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-3scale
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796946e+09
    - "0"
  resultType: vector
- name: 3scale_workload_app_downtime_seconds
  query: sum(workload_app_service_downtime_seconds{name='3scale_service'})
  result:
  - metric: {}
    value:
    - 1.602166796946e+09
    - "10030"
  resultType: vector
- name: rhssouser_keycloak_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak',
    namespace='redhat-rhmi-user-sso'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: keycloak
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-user-sso
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796948e+09
    - "0"
  resultType: vector
- name: rhssouser_keycloak_discovery_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery',
    namespace='redhat-rhmi-user-sso'} , 1)[$duration:30s]) * $range)/1000
  result:
  - metric:
      endpoint: keycloak-discovery
      instance: 10.130.6.41:8443
      job: kube-state-metrics
      namespace: redhat-rhmi-user-sso
      pod: kube-state-metrics-5fc5b5794f-ljd86
      prometheus: openshift-monitoring/k8s
      service: kube-state-metrics
    value:
    - 1.602166796965e+09
    - "0"
  resultType: vector
- name: rhssouser_ui_blackbox_downtime_seconds
  query: $range - (probe_success{service='rhssouser-ui'} * $range)
  result:
  - metric:
      instance: https://keycloak-edge-redhat-rhmi-user-sso.apps.mw-collab-multi.v6b0.s1.devshift.org
      job: blackbox
      service: rhssouser-ui
    value:
    - 1.602166796965e+09
    - "0"
  resultType: vector
- name: rhssouser_workload_app_downtime_seconds
  query: sum(workload_app_service_downtime_seconds{name='sso_service'})
  result:
  - metric: {}
    value:
    - 1.602166796965e+09
    - "20"
  resultType: vector
- name: rhsso_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak',
    namespace='redhat-rhmi-sso'} , 1)[$duration:30s]) * $range)/1000
  result: []
  resultType: vector
- name: rhsso_keycloak_discovery_k8s_endpoint_downtime_seconds
  query: ($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery',
    namespace='redhat-rhmi-sso'} , 1)[$duration:30s]) * $range)/1000
  result: []
  resultType: vector
- name: rhsso_ui_blackbox_downtime_seconds
  query: $range - (probe_success{service='rhsso-ui'} * $range)
  result:
  - metric:
      instance: https://keycloak-edge-redhat-rhmi-rhsso.apps.mw-collab-multi.v6b0.s1.devshift.org
      job: blackbox
      service: rhsso-ui
    value:
    - 1.602166796986e+09
    - "0"
  resultType: vector
version: ""
```