### PR TITLE
ocm: fix: cluster name (added display_name)

### DIFF
--- a/templates/ocm/cluster-template.json
+++ b/templates/ocm/cluster-template.json
@@ -1,5 +1,6 @@
 {
     "byoc": false,
+    "display_name": "long_cluster_name",
     "managed": true,
     "multi_az": false,
     "name": "my_cluster_name",


### PR DESCRIPTION
### What

If user sends a request to ocm for creating a cluster which name is more than 15 characters long, it fails with following error:
```
05:38:10  {
05:38:10    "kind": "Error",
05:38:10    "id": "400",
05:38:10    "href": "/api/clusters_mgmt/v1/errors/400",
05:38:10    "code": "CLUSTERS-MGMT-400",
05:38:10    "reason": "Cluster name 'rhoam-master-20-093454639246' is 28 characters long - its length exceeds the maximum length allowed of 15 characters",
05:38:10    "operation_id": "1ga29841ac0b8n9j3nijkoagqf2n3dbl"
05:38:10  }
```

As a workaround, we can use `display_name` property that allows to store a very long string (more than 100 characters - I haven't tested the actual limit)

### Verification

https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/ManagedAPI/job/managed-api-install-master/27/console

<img width="529" alt="Screenshot 2020-10-14 at 09 26 42" src="https://user-images.githubusercontent.com/4881144/95957004-68bd7380-0dff-11eb-9949-8ab405bbabb0.png">
