### PR TITLE
Openshift CI Release update for RHOAM

### DIFF
--- a/cmd/mergeRelease.go
+++ b/cmd/mergeRelease.go
@@ -12,6 +12,7 @@ import (
 type mergeReleaseOptions struct {
 	releaseVersion string
 	baseBranch     string
+	olmType        string
 }
 
 var mergeReleaseCmdOpts = &mergeReleaseOptions{}
@@ -30,6 +31,7 @@ var mergeReleaseCmd = &cobra.Command{
 		client := newGithubClient(token)
 		repoInfo := &githubRepoInfo{owner: integreatlyGHOrg, repo: integreatlyOperatorRepo}
 		mergeReleaseCmdOpts.releaseVersion = releaseVersion
+		mergeReleaseCmdOpts.olmType = olmType
 		if err = DoMergeRelease(cmd.Context(), client.PullRequests, repoInfo, mergeReleaseCmdOpts); err != nil {
 			handleError(err)
 		}
@@ -37,7 +39,7 @@ var mergeReleaseCmd = &cobra.Command{
 }
 
 func DoMergeRelease(ctx context.Context, client services.PullRequestsService, repoInfo *githubRepoInfo, cmdOpts *mergeReleaseOptions) error {
-	rv, err := utils.NewRHMIVersion(cmdOpts.releaseVersion)
+	rv, err := utils.NewVersion(cmdOpts.releaseVersion, cmdOpts.olmType)
 	if err != nil {
 		return err
 	}

--- a/cmd/mergeRelease_test.go
+++ b/cmd/mergeRelease_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/google/go-github/v30/github"
 	"github.com/integr8ly/delorean/pkg/services"
+	"github.com/integr8ly/delorean/pkg/types"
 	"net/http"
 	"testing"
 )
@@ -85,7 +86,7 @@ func TestDoMergeRelease(t *testing.T) {
 					}, responseWithCode(http.StatusOK), nil
 				},
 			},
-			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1"},
+			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1", olmType: types.OlmTypeRhmi},
 			expectError: false,
 		},
 		{
@@ -97,7 +98,7 @@ func TestDoMergeRelease(t *testing.T) {
 				MergeFunc: nil,
 				GetFunc:   nil,
 			},
-			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1"},
+			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1", olmType: types.OlmTypeRhmi},
 			expectError: true,
 		},
 		{
@@ -116,7 +117,7 @@ func TestDoMergeRelease(t *testing.T) {
 					return nil, nil, errors.New("get error")
 				},
 			},
-			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1"},
+			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1", olmType: types.OlmTypeRhmi},
 			expectError: true,
 		},
 		{
@@ -146,7 +147,7 @@ func TestDoMergeRelease(t *testing.T) {
 					}, responseWithCode(http.StatusOK), nil
 				},
 			},
-			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1"},
+			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1", olmType: types.OlmTypeRhmi},
 			expectError: false,
 		},
 		{
@@ -176,7 +177,7 @@ func TestDoMergeRelease(t *testing.T) {
 					}, responseWithCode(http.StatusOK), nil
 				},
 			},
-			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1"},
+			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1", olmType: types.OlmTypeRhmi},
 			expectError: true,
 		},
 		{
@@ -206,7 +207,7 @@ func TestDoMergeRelease(t *testing.T) {
 					}, responseWithCode(http.StatusOK), nil
 				},
 			},
-			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1"},
+			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1", olmType: types.OlmTypeRhmi},
 			expectError: true,
 		},
 		{
@@ -238,7 +239,7 @@ func TestDoMergeRelease(t *testing.T) {
 					}, responseWithCode(http.StatusOK), nil
 				},
 			},
-			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1"},
+			opts:        &mergeReleaseOptions{baseBranch: "master", releaseVersion: "2.0.0-rc1", olmType: types.OlmTypeRhmi},
 			expectError: true,
 		},
 	}

--- a/cmd/osdAddonRelease.go
+++ b/cmd/osdAddonRelease.go
@@ -236,7 +236,7 @@ func findChannel(addon *addonConfig, channelName string) *releaseChannel {
 }
 
 func newOSDAddonReleseCmd(flags *osdAddonReleaseFlags, gitlabToken string) (*osdAddonReleaseCmd, error) {
-	version, err := utils.NewRHMIVersion(flags.version)
+	version, err := utils.NewVersion(flags.version, olmType)
 	if err != nil {
 		return nil, err
 	}
@@ -255,7 +255,7 @@ func newOSDAddonReleseCmd(flags *osdAddonReleaseFlags, gitlabToken string) (*osd
 		return nil, fmt.Errorf("can not find channel %s for addon %s in config file %s", flags.channel, flags.addonName, flags.addonsConfig)
 	}
 
-	fmt.Printf("create osd addon release for %s v%s to the %s channel\n", flags.addonName, version, flags.channel)
+	fmt.Printf("create osd addon release for %s %s to the %s channel\n", flags.addonName, version.TagName(), flags.channel)
 
 	// Prepare the GitLab Client
 	gitlabClient, err := gitlab.NewClient(
@@ -294,7 +294,7 @@ func newOSDAddonReleseCmd(flags *osdAddonReleaseFlags, gitlabToken string) (*osd
 	csvDir, _, err := gitCloneService.CloneToTmpDir(
 		"addon-csv-",
 		currentAddon.CSV.Repo,
-		plumbing.NewTagReferenceName(fmt.Sprintf("v%s", version)),
+		plumbing.NewTagReferenceName(version.TagName()),
 	)
 	if err != nil {
 		return nil, err
@@ -464,7 +464,6 @@ func (c *osdAddonReleaseCmd) run() error {
 }
 
 func (c *osdAddonReleaseCmd) copyTheOLMManifests() (string, error) {
-
 	source := path.Join(c.addonDir, fmt.Sprintf("%s/%s", c.addonConfig.CSV.Path, c.version.Base()))
 
 	relativeDestination := fmt.Sprintf("%s/%s", c.currentChannel.bundlesDirectory(), c.version.Base())

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -20,6 +20,7 @@ var cfgFile string
 var integreatlyGHOrg string
 var integreatlyOperatorRepo string
 var releaseVersion string
+var olmType string
 
 var kubeconfigFile string
 
@@ -104,6 +105,7 @@ func init() {
 	releaseCmd.PersistentFlags().StringVarP(&integreatlyOperatorRepo, "repo", "r", DefaultIntegreatlyOperatorRepo, "Github repository")
 	releaseCmd.PersistentFlags().String("quayToken", "", fmt.Sprintf("Access token for quay. Can be set via the %s env var", strings.ToUpper(QuayTokenKey)))
 	viper.BindPFlag(QuayTokenKey, releaseCmd.PersistentFlags().Lookup("quayToken"))
+	releaseCmd.PersistentFlags().StringVarP(&olmType, "olmType", "", DefaultIntegreatlyOperatorRepo, "OLM type for the release. Valid inputs are \"integreatly-operator\" or \"managed-api-service\"")
 
 	defaultKubeconfigFilePath := ""
 	if home := homedir.HomeDir(); home != "" {

--- a/cmd/tagRelease.go
+++ b/cmd/tagRelease.go
@@ -26,6 +26,7 @@ type tagReleaseOptions struct {
 	waitInterval   int64
 	waitMax        int64
 	quayRepos      string
+	olmType        string
 }
 
 var tagReleaseCmdOpts = &tagReleaseOptions{}
@@ -50,6 +51,7 @@ var tagReleaseCmd = &cobra.Command{
 		quayClient := newQuayClient(quayToken)
 		repoInfo := &githubRepoInfo{owner: integreatlyGHOrg, repo: integreatlyOperatorRepo}
 		tagReleaseCmdOpts.releaseVersion = releaseVersion
+		tagReleaseCmdOpts.olmType = olmType
 		if err = DoTagRelease(cmd.Context(), ghClient.Git, repoInfo, quayClient, tagReleaseCmdOpts); err != nil {
 			handleError(err)
 		}
@@ -57,7 +59,7 @@ var tagReleaseCmd = &cobra.Command{
 }
 
 func DoTagRelease(ctx context.Context, ghClient services.GitService, gitRepoInfo *githubRepoInfo, quayClient *quay.Client, cmdOpts *tagReleaseOptions) error {
-	rv, err := utils.NewVersion(cmdOpts.releaseVersion, olmType)
+	rv, err := utils.NewVersion(cmdOpts.releaseVersion, cmdOpts.olmType)
 	if err != nil {
 		return err
 	}

--- a/cmd/tagRelease.go
+++ b/cmd/tagRelease.go
@@ -57,7 +57,7 @@ var tagReleaseCmd = &cobra.Command{
 }
 
 func DoTagRelease(ctx context.Context, ghClient services.GitService, gitRepoInfo *githubRepoInfo, quayClient *quay.Client, cmdOpts *tagReleaseOptions) error {
-	rv, err := utils.NewRHMIVersion(cmdOpts.releaseVersion)
+	rv, err := utils.NewVersion(cmdOpts.releaseVersion, olmType)
 	if err != nil {
 		return err
 	}

--- a/cmd/tagRelease_test.go
+++ b/cmd/tagRelease_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/google/go-github/v30/github"
 	"github.com/integr8ly/delorean/pkg/quay"
 	"github.com/integr8ly/delorean/pkg/services"
+	"github.com/integr8ly/delorean/pkg/types"
 	"net/http"
 	"net/url"
 	"strings"
@@ -139,7 +140,7 @@ func TestDoTagRelease(t *testing.T) {
 					}}}, nil, nil
 				}},
 			},
-			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: quayRepos},
+			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: quayRepos, olmType: types.OlmTypeRhmi},
 			expectError:       false,
 		},
 		{
@@ -223,7 +224,7 @@ func TestDoTagRelease(t *testing.T) {
 					}}}, nil, nil
 				}},
 			},
-			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0", branch: "master", wait: false, quayRepos: quayRepos},
+			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0", branch: "master", wait: false, quayRepos: quayRepos, olmType: types.OlmTypeRhmi},
 			expectError:       false,
 		},
 		{
@@ -280,7 +281,7 @@ func TestDoTagRelease(t *testing.T) {
 					}}}, nil, nil
 				}},
 			},
-			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0", branch: "master", wait: false, quayRepos: quayRepos},
+			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0", branch: "master", wait: false, quayRepos: quayRepos, olmType: types.OlmTypeRhmi},
 			expectError:       false,
 		},
 		{
@@ -338,7 +339,7 @@ func TestDoTagRelease(t *testing.T) {
 					}}}, nil, nil
 				}},
 			},
-			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.1-rc1", branch: "release-v2.0", wait: false, quayRepos: quayRepos},
+			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.1-rc1", branch: "release-v2.0", wait: false, quayRepos: quayRepos, olmType: types.OlmTypeRhmi},
 			expectError:       false,
 		},
 		{
@@ -371,7 +372,7 @@ func TestDoTagRelease(t *testing.T) {
 			quayClient: &quay.Client{
 				BaseURL: baseUrl,
 			},
-			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: quayRepos},
+			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: quayRepos, olmType: types.OlmTypeRhmi},
 			expectError:       true,
 		},
 		{
@@ -421,7 +422,7 @@ func TestDoTagRelease(t *testing.T) {
 					}}}, nil, nil
 				}},
 			},
-			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: quayRepos},
+			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: quayRepos, olmType: types.OlmTypeRhmi},
 			expectError:       true,
 		},
 		{
@@ -447,7 +448,7 @@ func TestDoTagRelease(t *testing.T) {
 					}, nil, nil
 				},
 			},
-			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: ""},
+			tagReleaseOptions: &tagReleaseOptions{releaseVersion: "2.0.0-rc1", branch: "master", wait: false, quayRepos: "", olmType: types.OlmTypeRhmi},
 			expectError:       false,
 		},
 	}

--- a/cmd/tagRepository.go
+++ b/cmd/tagRepository.go
@@ -16,6 +16,7 @@ type tagRepositoryFlags struct {
 	repository     string
 	branch         string
 	skipPreRelease bool
+	olmType        string
 }
 
 func init() {
@@ -38,6 +39,7 @@ func init() {
 				handleError(errors.New("version is not defined"))
 			}
 
+			flags.olmType = olmType
 			if err := runTagRepository(cmd.Context(), ghClient.Git, version, flags); err != nil {
 				handleError(err)
 			}
@@ -55,7 +57,7 @@ func init() {
 }
 
 func runTagRepository(ctx context.Context, ghClient services.GitService, version string, flags *tagRepositoryFlags) error {
-	v, err := utils.NewVersion(version, olmType)
+	v, err := utils.NewVersion(version, flags.olmType)
 	if err != nil {
 		return err
 	}

--- a/cmd/tagRepository.go
+++ b/cmd/tagRepository.go
@@ -55,7 +55,7 @@ func init() {
 }
 
 func runTagRepository(ctx context.Context, ghClient services.GitService, version string, flags *tagRepositoryFlags) error {
-	v, err := utils.NewRHMIVersion(version)
+	v, err := utils.NewVersion(version, olmType)
 	if err != nil {
 		return err
 	}

--- a/cmd/tagRepository_test.go
+++ b/cmd/tagRepository_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"errors"
+	"github.com/integr8ly/delorean/pkg/types"
 	"strings"
 	"testing"
 
@@ -45,7 +46,7 @@ func TestTagRepository(t *testing.T) {
 				},
 			},
 			version:     "2.0.0-rc1",
-			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: false},
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: false, olmType: types.OlmTypeRhmi},
 			expectError: false,
 		},
 		{
@@ -71,7 +72,7 @@ func TestTagRepository(t *testing.T) {
 				},
 			},
 			version:     "2.0.0",
-			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: true},
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: true, olmType: types.OlmTypeRhmi},
 			expectError: false,
 		},
 		{
@@ -85,7 +86,7 @@ func TestTagRepository(t *testing.T) {
 				},
 			},
 			version:     "2.0.0-rc1",
-			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: true},
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: true, olmType: types.OlmTypeRhmi},
 			expectError: false,
 		},
 		{
@@ -107,7 +108,7 @@ func TestTagRepository(t *testing.T) {
 				},
 			},
 			version:     "2.0.0-rc1",
-			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: false},
+			flags:       &tagRepositoryFlags{branch: "master", organization: "test", repository: "test", skipPreRelease: false, olmType: types.OlmTypeRhmi},
 			expectError: true,
 		},
 	}

--- a/configurations/managed-tenants-addons-config-rhoam.yaml
+++ b/configurations/managed-tenants-addons-config-rhoam.yaml
@@ -1,0 +1,33 @@
+---
+addons:
+  - name: "rhoam-operator"
+    csv:
+      repo: "https://github.com/integr8ly/integreatly-operator.git"
+      path: "deploy/olm-catalog/managed-api-service"
+    channels:
+      - name: "stage"
+        directory: "rhoam-operator"
+        environment: "stage"
+        allow_pre_release: true
+      - name: "edge"
+        directory: "rhoam-operator-internal"
+        environment: "production"
+        allow_pre_release: false
+      - name: "stable"
+        directory: "rhoam-operator"
+        environment: "production"
+        allow_pre_release: false
+    override:
+      deployment:
+        name: "rhoam-operator"
+        container:
+          name: "rhoam-operator"
+          env_vars:
+            - name: "INSTALLATION_TYPE"
+              value: "managed-api"
+            - name: "USE_CLUSTER_STORAGE"
+              value: ""
+            - name: "ALERTING_EMAIL_ADDRESS"
+              value: "{{ alertingEmailAddress }}"
+
+

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,6 @@
+package types
+
+const (
+	OlmTypeRhmi  = "integreaty-operator"
+	OlmTypeRhoam = "managed-api-service"
+)

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,6 +1,6 @@
 package types
 
 const (
-	OlmTypeRhmi  = "integreaty-operator"
+	OlmTypeRhmi  = "integreatly-operator"
 	OlmTypeRhoam = "managed-api-service"
 )

--- a/pkg/utils/rhmi_version.go
+++ b/pkg/utils/rhmi_version.go
@@ -42,8 +42,23 @@ func NewRHMIVersion(version string) (*RHMIVersion, error) {
 	}
 }
 
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
 // NewVersion parse the version as a string based on olmType and returns a Version object
 func NewVersion(version string, olmType string) (*RHMIVersion, error) {
+
+	acceptedOlmTypes := []string{types.OlmTypeRhmi, types.OlmTypeRhoam}
+	if !stringInSlice(olmType, acceptedOlmTypes) {
+		return nil, fmt.Errorf("the olmType %s is invalid", olmType)
+	}
+
 	ver, err := NewRHMIVersion(version)
 	if err != nil {
 		return nil, err

--- a/pkg/utils/rhmi_version.go
+++ b/pkg/utils/rhmi_version.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"fmt"
+	"github.com/integr8ly/delorean/pkg/types"
 	"strings"
 )
 
@@ -10,11 +11,12 @@ const releaseBranchNameTemplate = "prepare-for-release-%s"
 // RHMIVersion rappresents an integreatly version composed by a base part (2.0.0, 2.0.1, ...)
 // and a build part (ER1, RC2, ..) if it's a prerelase version
 type RHMIVersion struct {
-	base  string
-	build string
-	major string
-	minor string
-	patch string
+	base    string
+	build   string
+	major   string
+	minor   string
+	patch   string
+	olmType string
 }
 
 // NewRHMIVersion parse the integreatly version as a string and returns a Version object
@@ -28,16 +30,28 @@ func NewRHMIVersion(version string) (*RHMIVersion, error) {
 	switch len(p) {
 	case 1:
 		parts := strings.Split(p[0], ".")
-		return &RHMIVersion{base: p[0], build: "", major: parts[0], minor: parts[1], patch: parts[2]}, nil
+		return &RHMIVersion{base: p[0], build: "", major: parts[0], minor: parts[1], patch: parts[2], olmType: types.OlmTypeRhmi}, nil
 	case 2:
 		if p[1] == "" {
 			return nil, fmt.Errorf("the build part of the version %s is empty", version)
 		}
 		parts := strings.Split(p[0], ".")
-		return &RHMIVersion{base: p[0], build: p[1], major: parts[0], minor: parts[1], patch: parts[2]}, nil
+		return &RHMIVersion{base: p[0], build: p[1], major: parts[0], minor: parts[1], patch: parts[2], olmType: types.OlmTypeRhmi}, nil
 	default:
 		return nil, fmt.Errorf("the version %s is invalid", version)
 	}
+}
+
+// NewVersion parse the version as a string based on olmType and returns a Version object
+func NewVersion(version string, olmType string) (*RHMIVersion, error) {
+	ver, err := NewRHMIVersion(version)
+	if err != nil {
+		return nil, err
+	}
+	if ver != nil {
+		ver.olmType = olmType
+	}
+	return ver, nil
 }
 
 func (v *RHMIVersion) String() string {
@@ -54,16 +68,37 @@ func (v *RHMIVersion) IsPreRelease() bool {
 }
 
 func (v *RHMIVersion) ReleaseBranchName() string {
-	return fmt.Sprintf("release-v%s", v.MajorMinor())
+	switch v.olmType {
+	case types.OlmTypeRhmi:
+		return fmt.Sprintf("release-v%s", v.MajorMinor())
+	case types.OlmTypeRhoam:
+		return fmt.Sprintf("rhoam-release-v%s", v.MajorMinor())
+	default:
+		return fmt.Sprintf("release-v%s", v.MajorMinor())
+	}
 }
 
 func (v *RHMIVersion) TagName() string {
-	return fmt.Sprintf("v%s", v.String())
+	switch v.olmType {
+	case types.OlmTypeRhmi:
+		return fmt.Sprintf("v%s", v.String())
+	case types.OlmTypeRhoam:
+		return fmt.Sprintf("rhoam-v%s", v.String())
+	default:
+		return fmt.Sprintf("v%s", v.String())
+	}
 }
 
 // RCTagRef returns a git ref that can be used to search for all RC Tags for this version
 func (v *RHMIVersion) RCTagRef() string {
-	return fmt.Sprintf("v%s-", v.MajorMinorPatch())
+	switch v.olmType {
+	case types.OlmTypeRhmi:
+		return fmt.Sprintf("v%s-", v.MajorMinorPatch())
+	case types.OlmTypeRhoam:
+		return fmt.Sprintf("rhoam-v%s-", v.MajorMinorPatch())
+	default:
+		return fmt.Sprintf("v%s-", v.MajorMinorPatch())
+	}
 }
 
 func (v *RHMIVersion) Base() string {
@@ -110,4 +145,8 @@ func (v *RHMIVersion) ReleaseBranchImageTag() string {
 	} else {
 		return "master"
 	}
+}
+
+func (v *RHMIVersion) OlmType() string {
+	return v.olmType
 }

--- a/pkg/utils/rhmi_version_test.go
+++ b/pkg/utils/rhmi_version_test.go
@@ -101,6 +101,7 @@ func TestRHMIVersion_InitialPointReleaseTag(t *testing.T) {
 		name    string
 		version string
 		want    string
+		olmType string
 	}{
 		{
 			name:    "test same point value",
@@ -138,6 +139,7 @@ func TestRHMIVersion_MajorMinor(t *testing.T) {
 		name    string
 		version string
 		want    string
+		olmType string
 	}{
 		{
 			name:    "test same point value",


### PR DESCRIPTION
These changes allow the use of a rhoam prefix to branch names.
Selectable by a input flag of --olmType. The default for the flag is integreatly-operator.
Images that are mirrored from prow has also been updated to suit the new install type.

**JIRA** 
https://issues.redhat.com/browse/MGDAPI-31
https://issues.redhat.com/browse/MGDAPI-245

**Requires https://github.com/integr8ly/integreatly-operator/pull/1155 to be merged**

Sample out put which would be created in a pr to openshift/release can been seen here. https://github.com/Boomatang/release/pull/4
Command used to create the pr was. values for the upstream was changed to from the openshift/release to Boomatang/release. this was a hard code value change and has been reverted in this pr.
```
GITHUB_TOKEN=<TOKEN> GITHUB_USER="Boomatang" ./delorean release openshift-ci-release --version 99.999.999 -o Boomatang --olmType managed-api-service
```