### PR TITLE
MGDAPI-499 - add BU email and fix RHOAM env var overrides

### DIFF
--- a/configurations/managed-tenants-addons-config-rhoam.yaml
+++ b/configurations/managed-tenants-addons-config-rhoam.yaml
@@ -19,9 +19,9 @@ addons:
         allow_pre_release: false
     override:
       deployment:
-        name: "rhoam-operator"
+        name: "rhmi-operator"
         container:
-          name: "rhoam-operator"
+          name: "rhmi-operator"
           env_vars:
             - name: "INSTALLATION_TYPE"
               value: "managed-api"
@@ -29,5 +29,7 @@ addons:
               value: ""
             - name: "ALERTING_EMAIL_ADDRESS"
               value: "{{ alertingEmailAddress }}"
+            - name: "BU_ALERTING_EMAIL_ADDRESS"
+              value: "{{ buAlertingEmailAddress }}"
 
 


### PR DESCRIPTION
JIRA: https://issues.redhat.com/browse/MGDAPI-499

Environment variable overrides were not getting applied, see https://gitlab.cee.redhat.com/service/managed-tenants/-/blob/c2a36cf1523bfb657ca1ede30f853e480868148d/addons/managed-api-service/bundles/0.2.0/managed-api-service.v0.2.0.clusterserviceversion.yaml.j2#L329
Also, BU email env var was missing.

I think that overrides didn't work because of the deployment and container names used.
I am changing those in the configuration file, but as an alternative, we could change them in the CSV in integreatly-operator repo. Wdyt @philbrookes @pwright @laurafitzgerald  ?