### PR TITLE
fix: don't panic but return the error

### DIFF
--- a/cmd/polarionImport.go
+++ b/cmd/polarionImport.go
@@ -251,7 +251,7 @@ func (c *polarionImportCmd) importToPolarion(key string, metadata *testMetadata,
 			fmt.Printf("[%s] polarion job completed successfully\n", key)
 			exit = true
 		default:
-			panic(fmt.Errorf("unknown job status %s", status))
+			return fmt.Errorf("[%s] unknown job status %s", key, status)
 		}
 
 		if exit {


### PR DESCRIPTION
If the Polarion import fails just return the error and the zip file name