### PR TITLE
fix: rhmi vs rhoam namespace

### DIFF
--- a/docs/ocm/README.md
+++ b/docs/ocm/README.md
@@ -1,4 +1,4 @@
-## Using `ocm` for installation of RHMI or Managed API Service
+## Using `ocm` for installation of RHMI or Managed API Service (RHOAM)
 
 If you want to test your changes on a cluster, the easiest solution would be to spin up OSD 4 cluster using `ocm`. If you want to spin up a cluster using CCS (Cloud Customer Subscription, previously called "BYOC"), follow the additional steps marked as **BYOC**.
 
@@ -69,7 +69,7 @@ oc --config ocm/cluster.kubeconfig projects
 
 7. If you want to install the latest release, you can trigger it by applying an addon
     1. For **RHMI**: Run `make ocm/install/rhmi-addon` to trigger the installation
-    2. For **Managed API Service**: Run `make ocm/install/managed-api-addon` to trigger the installaion
+    2. For **Managed API Service (RHOAM)**: Run `make ocm/install/rhoam-addon` to trigger the installaion
   
     Once the installation is completed, the installation CR with RHMI components info will be printed to the console
 

--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -40,9 +40,9 @@ ocm/cluster/create:
 ocm/install/rhmi-addon:
 	@${OCM_SH} install_rhmi
 
-.PHONY: ocm/install/managed-api-addon
-ocm/install/managed-api-addon:
-	@${OCM_SH} install_managed_api
+.PHONY: ocm/install/rhoam-addon
+ocm/install/rhoam-addon:
+	@${OCM_SH} install_rhoam
 
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:

--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -155,7 +155,7 @@ install_addon() {
 
     echo "Patching RHMI CR"
     oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" patch rhmi "${rhmi_name}" -n "${OPERATOR_NAMESPACE}" \
-        --type=merge -p "{\"spec\":{\"useClusterStorage\": \"${USE_CLUSTER_STORAGE}\", \"selfSignedCerts\": ${SELF_SIGNED_CERTS:-true} }}"
+        --type=merge -p "{\"spec\":{\"useClusterStorage\": \"${USE_CLUSTER_STORAGE}\", \"selfSignedCerts\": ${SELF_SIGNED_CERTS:-false} }}"
 
     # Change alerting email address is ALERTING_EMAIL_ADDRESS variable is set
     if [[ -n "${ALERTING_EMAIL_ADDRESS:-}" ]]; then
@@ -182,7 +182,7 @@ install_rhmi() {
     install_addon "rhmi" ".status.stages.\\\"solution-explorer\\\".phase"
 }
 
-install_managed_api() {
+install_rhoam() {
     NS_PREFIX="redhat-rhoam"
     OPERATOR_NAMESPACE="${NS_PREFIX}-operator"
     install_addon "managed-api-service" ".status.stages.products.phase"
@@ -367,9 +367,8 @@ Optional exported variables:
 create_cluster                    - spin up OSD cluster
 ==========================================================================================================
 install_rhmi                      - install RHMI using addon-type installation
-==========================================================================================================
-install_managed_api               - install Managed API Service using addon-type installation
-----------------------------------------------------------------------------------------------------------
+install_rhoam                     - install RHOAM using addon-type installation
+------------------------------------------------------------------------------------------
 Optional exported variables:
 - USE_CLUSTER_STORAGE               true/false - use OpenShift/AWS storage (default: true)
 - ALERTING_EMAIL_ADDRESS            email address for receiving alert notifications
@@ -407,8 +406,8 @@ main() {
             install_rhmi
             exit 0
             ;;
-        install_managed_api)
-            install_managed_api
+        install_rhoam)
+            install_rhoam
             exit 0
             ;;
         delete_cluster)

--- a/templates/ocm/cr-aws-strategies.yml
+++ b/templates/ocm/cr-aws-strategies.yml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: cloud-resources-aws-strategies
-  namespace: redhat-rhmi-operator
 data:
   blobstorage: |
     {"production": { "createStrategy": {}, "deleteStrategy": {} }}


### PR DESCRIPTION
### What
Use `redhat-rhoam-operator` namespace instead of `redhat-rhmi-operator` in case of **RHOAM addon-flow installation**

### Why
Namespace prefix for RHOAM services [recently got changed](https://issues.redhat.com/browse/MGDAPI-419)

### When is this PR ready to be merged?
Once we have:
* https://issues.redhat.com/browse/MGDAPI-547 done and merged to master branch
* new release of RHOAM available in MT

### Follow-up MR
* https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/merge_requests/349