### PR TITLE
feat: create release in Polarion per product

### DIFF
--- a/cmd/polarionImport.go
+++ b/cmd/polarionImport.go
@@ -221,7 +221,9 @@ func (c *polarionImportCmd) importToPolarion(key string, metadata *testMetadata,
 	}
 
 	title := fmt.Sprintf("RHMI %s %s Automated Tests", version.String(), metadata.Name)
-	xunit, err := polarion.JUnitToPolarionXUnit(junit, polarionProjectID, title, version.PolarionMilestoneId())
+	// TODO
+	// Add support for importing RHOAM test results
+	xunit, err := polarion.JUnitToPolarionXUnit(junit, polarionProjectIDs["rhmi"], title, version.PolarionMilestoneId())
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDAPI-515

followed-up by https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/merge_requests/351/diffs

### How the changes were tested
```bash
$ make build/cli
GOFLAGS=-mod=vendor go build -o=./ .

# Show the usage - note the new parameter product-name
$ ./delorean report polarion-release -h                                         
Prepare the release version in Polarion

Usage:
  delorean report polarion-release [flags]

Flags:
      --debug                 Print the Polarion API request and response
  -h, --help                  help for polarion-release
      --product-name string   Name of the product. Valid inputs are: "rhmi", "rhoam"
      --stage                 Create the release in the Polarion staging environment
      --version string        The RHMI/RHOAM version to create in Polarion (ex "2.0.0", "2.0.0-er4")

Global Flags:
      --config string   config file (default is $HOME/.delorean.yaml)

# Create a new release in Polarion for RHOAM
$ ./delorean report polarion-release --product-name rhoam --version 0.3.0-deleteme                                                     
the release 'v0_3_0' has been created
the milestone 'v0_3_0_deleteme' has been created
the test run template 'v0_3_0_deleteme' has been created

# Create a new release in Polarion for RHMI
$ ./delorean report polarion-release --product-name rhmi --version 0.3.0-deleteme                   
the release 'v0_3_0' has been created
the milestone 'v0_3_0_deleteme' has been created
the test run template 'v0_3_0_deleteme' has been created

```