### PR TITLE
Set useClusterStorage for RHOAM

### DIFF
--- a/configurations/managed-tenants-addons-config-rhoam.yaml
+++ b/configurations/managed-tenants-addons-config-rhoam.yaml
@@ -26,7 +26,7 @@ addons:
             - name: "INSTALLATION_TYPE"
               value: "managed-api"
             - name: "USE_CLUSTER_STORAGE"
-              value: ""
+              value: "{{ useClusterStorage }}"
             - name: "ALERTING_EMAIL_ADDRESS"
               value: "{{ alertingEmailAddress }}"
             - name: "BU_ALERTING_EMAIL_ADDRESS"


### PR DESCRIPTION
There's an MR opened in MTR to support setting the clusterStorage value in addon.yaml. This PR aims to populate the useClusterStorage value in the j2 CSV with addon.yaml value.