### PR TITLE
mgdapi-304-create-manifest

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,19 +3,22 @@ LABEL maintainer="mnairn@redhat.com"
 
 ENV OPERATOR_SDK_VERSION=v0.15.1 \
     OC_VERSION="4.5" \
-    GOFLAGS=""
+    GOFLAGS="" \
+    PATH=$PATH:/usr/local/go/bin
 
 COPY resources/rhit-root-ca.crt /etc/pki/ca-trust/source/anchors/
 
 RUN set -o pipefail && \
-    INSTALL_PKGS="make rsync" && \
+    INSTALL_PKGS="make rsync wget" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     curl -Ls https://mirror.openshift.com/pub/openshift-v4/clients/oc/$OC_VERSION/linux/oc.tar.gz | tar -zx && \
     mv oc /usr/local/bin && \
     curl -Lo /usr/local/bin/yq https://github.com/mikefarah/yq/releases/download/3.1.2/yq_linux_amd64 && \
     chmod +x /usr/local/bin/yq && \
     curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
-    chmod +x /usr/local/bin/jq
+    chmod +x /usr/local/bin/jq && \
+    wget https://golang.org/dl/go1.15.5.linux-amd64.tar.gz && \
+    tar -zxvf go1.15.5.linux-amd64.tar.gz -C /usr/local/
 
 # install operator-sdk
 RUN curl -LO https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk-${OPERATOR_SDK_VERSION}-x86_64-linux-gnu && \

--- a/cmd/createProdsecManifest.go
+++ b/cmd/createProdsecManifest.go
@@ -1,0 +1,265 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/go-git/go-git/v5/plumbing/transport/http"
+	"github.com/google/go-github/v30/github"
+	"github.com/integr8ly/delorean/pkg/services"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"github.com/spf13/cobra"
+	"io"
+	"os"
+	"os/exec"
+	"path"
+	"time"
+)
+
+type createProdsecManifestCmdFlags struct {
+	baseBranch     string
+	manifestScript string
+}
+
+type createProdsecManifestCmd struct {
+	version         *utils.RHMIVersion
+	repoInfo        *githubRepoInfo
+	baseBranch      plumbing.ReferenceName
+	githubPRService services.PullRequestsService
+	manifestScript  string
+	gitUser         string
+	gitPass         string
+	gitCloneService services.GitCloneService
+	gitPushService  services.GitPushService
+}
+
+func init() {
+	f := &createProdsecManifestCmdFlags{}
+
+	cmd := &cobra.Command{
+		Use:   "create-prodsec-manifest",
+		Short: "Create a production manifest of a given version and olm type",
+		Run: func(cmd *cobra.Command, args []string) {
+			c, err := newCreateProdsecManifestCmd(f)
+			if err != nil {
+				handleError(err)
+			}
+			var repoDir string
+			if repoDir, err = c.run(cmd.Context()); err != nil {
+				handleError(err)
+			}
+			if repoDir != "" {
+				fmt.Println("Remove temporary directory:", repoDir)
+				if err = os.RemoveAll(repoDir); err != nil {
+					handleError(err)
+				}
+			}
+		},
+	}
+
+	releaseCmd.AddCommand(cmd)
+	cmd.Flags().StringVarP(&f.baseBranch, "branch", "b", "master", "Base branch of the manifest generation")
+	cmd.Flags().StringVar(&f.manifestScript, "manifestGenerationScript", "scripts/prodsec-manifest-generator.sh", "Relative path to the script to run before creating the PR")
+}
+
+func newCreateProdsecManifestCmd(f *createProdsecManifestCmdFlags) (*createProdsecManifestCmd, error) {
+	var token string
+	var err error
+	if token, err = requireValue(GithubTokenKey); err != nil {
+		return nil, err
+	}
+	var user string
+	if user, err = requireValue(GithubUserKey); err != nil {
+		return nil, err
+	}
+	client := newGithubClient(token)
+	repoInfo := &githubRepoInfo{owner: integreatlyGHOrg, repo: integreatlyOperatorRepo}
+	baseBranch := plumbing.NewBranchReferenceName(f.baseBranch)
+	version, err := utils.NewVersion(releaseVersion, olmType)
+	if err != nil {
+		return nil, err
+	}
+	return &createProdsecManifestCmd{
+		version:         version,
+		repoInfo:        repoInfo,
+		baseBranch:      baseBranch,
+		manifestScript:  f.manifestScript,
+		githubPRService: client.PullRequests,
+		gitUser:         user,
+		gitPass:         token,
+		gitCloneService: &services.DefaultGitCloneService{},
+		gitPushService:  &services.DefaultGitPushService{},
+	}, nil
+}
+
+func (c *createProdsecManifestCmd) run(ctx context.Context) (string, error) {
+	// Clone the repo
+	fmt.Println(fmt.Sprintf("Clone repo from %s/%s/%s.git to a temporary directory", githubURL, c.repoInfo.owner, c.repoInfo.repo))
+	repoDir, gitRepo, err := c.gitCloneService.CloneToTmpDir("integreatly-operator", fmt.Sprintf("%s/%s/%s.git", githubURL, c.repoInfo.owner, c.repoInfo.repo), c.baseBranch)
+	if err != nil {
+		return "", err
+	}
+
+	fmt.Println("Repo cloned to", repoDir)
+	gitRepoTree, err := gitRepo.Worktree()
+	if err != nil {
+		return "", err
+	}
+
+	// Checking out the OLM_TYPE-release-VERSION branch as the manifest generation script must be run from this branch
+	releasedBranchName := c.version.ReleaseBranchName()
+	fmt.Println(fmt.Sprintf("Checkout branch %s", releasedBranchName))
+	if err = checkoutBranch(gitRepoTree, false, false, releasedBranchName); err != nil {
+		return "", err
+	}
+
+	// Invoking manifest generation script
+	fmt.Println(fmt.Sprintf("Generate manifest: %s", c.manifestScript))
+	if err = c.runManifestScript(repoDir); err != nil {
+		return "", err
+	}
+
+	manifestFileName := fmt.Sprintf("%s-production-release-manifest.txt", c.version.NameByOlmType())
+	manifestPath := fmt.Sprintf("%s/prodsec-manifests/%s", repoDir, manifestFileName)
+	temporaryManifestPath := fmt.Sprintf("%s/../temporary-manifest.txt", repoDir)
+
+	// Saving generated manifest file - reason for it is as we need to checkout master without saving local changes to the repo.
+	if err = copyManifestFile(manifestPath, temporaryManifestPath); err != nil {
+		return "", err
+	}
+
+	// Checking out master branch to be able to checkout new branch from it
+	fmt.Println("Checkout master branch")
+	if err = checkoutBranch(gitRepoTree, true, false, "master"); err != nil {
+		return "", err
+	}
+
+	// Preparing new branch called OLM_TYPE-manifest-for-release-OLM_TYPE-VERSION of release
+	manifestReleaseBranchName := c.version.PrepareProdsecManifestBranchName()
+	fmt.Println(fmt.Sprintf("Create new branch %s", manifestReleaseBranchName))
+	if err = checkoutBranch(gitRepoTree, true, true, manifestReleaseBranchName); err != nil {
+		return "", err
+	}
+
+	// Restoring saved file to a new branch
+	if err = copyManifestFile(temporaryManifestPath, manifestPath); err != nil {
+		return "", err
+	}
+
+	status, err := gitRepoTree.Status()
+	if err != nil {
+		return "", err
+	}
+	if len(status) > 0 {
+		if err = c.commitAndPushChanges(gitRepo, gitRepoTree); err != nil {
+			return "", err
+		}
+	} else {
+		fmt.Println("No new changes found - seems that repo has up-to-date production manifest!")
+		return repoDir, nil
+	}
+
+	if err = c.createPRIfNotExists(ctx, manifestReleaseBranchName); err != nil {
+		return "", err
+	}
+
+	return repoDir, nil
+}
+
+func (c *createProdsecManifestCmd) runManifestScript(repoDir string) error {
+	if err := os.Chmod(path.Join(repoDir, c.manifestScript), 0755); err != nil {
+		return err
+	}
+
+	envs := []string{fmt.Sprintf("OLM_TYPE=%s", c.version.OlmType()), "TYPE_OF_MANIFEST=production", fmt.Sprintf("PATH=%s", os.Getenv("PATH")), "HOME=/tmp"}
+
+	manifestGeneratorScript := &exec.Cmd{Dir: repoDir, Env: envs, Path: c.manifestScript, Stdout: os.Stdout, Stderr: os.Stderr}
+	return manifestGeneratorScript.Run()
+}
+
+func (c *createProdsecManifestCmd) commitAndPushChanges(gitRepo *git.Repository, gitRepoTree *git.Worktree) error {
+	fmt.Println("Commit new changes")
+	if err := gitRepoTree.AddGlob("."); err != nil {
+		return err
+	}
+	if _, err := gitRepoTree.Commit(fmt.Sprintf("Prepare %s manifest for version %s", c.version.OlmType(), c.version.TagName()), &git.CommitOptions{
+		Author: &object.Signature{
+			Name:  commitAuthorName,
+			Email: commitAuthorEmail,
+			When:  time.Now(),
+		},
+	}); err != nil {
+		return err
+	}
+
+	fmt.Println("Push manifest release branch")
+	opts := &git.PushOptions{
+		RemoteName: "origin",
+		Auth:       &http.BasicAuth{Password: c.gitPass, Username: c.gitUser},
+		Progress:   os.Stdout,
+	}
+	if err := c.gitPushService.Push(gitRepo, opts); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *createProdsecManifestCmd) createPRIfNotExists(ctx context.Context, releaseBranchName string) error {
+	h := fmt.Sprintf("%s:%s", c.repoInfo.owner, releaseBranchName)
+	prOpts := &github.PullRequestListOptions{Base: c.baseBranch.String(), Head: h}
+	pr, err := findPRForRelease(ctx, c.githubPRService, c.repoInfo, prOpts)
+	if err != nil && !isPRNotFoundError(err) {
+		return err
+	}
+	if pr == nil {
+		fmt.Printf("Create PR for %s manifest version - %s", c.version.OlmType(), c.version.TagName())
+		t := fmt.Sprintf("Manifest PR for version %s", c.version.TagName())
+		b := c.baseBranch.String()
+		req := &github.NewPullRequest{
+			Title: &t,
+			Head:  &h,
+			Base:  &b,
+		}
+		pr, _, err = c.githubPRService.Create(ctx, c.repoInfo.owner, c.repoInfo.repo, req)
+		if err != nil {
+			return err
+		}
+	}
+	fmt.Println(fmt.Sprintf("PR created: %s", pr.GetHTMLURL()))
+	return nil
+}
+
+func checkoutBranch(repoWorkTree *git.Worktree, removeChanges bool, create bool, branchName string) error {
+	branch := plumbing.NewBranchReferenceName(branchName)
+	if err := repoWorkTree.Checkout(&git.CheckoutOptions{
+		Force:  removeChanges,
+		Branch: branch,
+		Create: create,
+	}); err != nil {
+		return err
+	}
+	return nil
+}
+
+func copyManifestFile(copyFrom string, copyTo string) error {
+	from, err := os.Open(copyFrom)
+	if err != nil {
+		return err
+	}
+	defer from.Close()
+
+	to, err := os.OpenFile(copyTo, os.O_RDWR|os.O_CREATE, 0666)
+	if err != nil {
+		return err
+	}
+	defer to.Close()
+
+	_, err = io.Copy(to, from)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/cmd/createProdsecManifest_test.go
+++ b/cmd/createProdsecManifest_test.go
@@ -1,0 +1,179 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/go-git/go-git/v5"
+	"github.com/go-git/go-git/v5/plumbing"
+	"github.com/go-git/go-git/v5/plumbing/object"
+	"github.com/google/go-github/v30/github"
+	"github.com/integr8ly/delorean/pkg/utils"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func newTestCreateProdsecManifestCmd(olmType string) *createProdsecManifestCmd {
+	version, _ := utils.NewVersion("1.0.0", olmType)
+
+	// Clone and initiate the mock integreatly repo from testdata/createRhoamManifest
+	cloneService := &mockGitCloneService{cloneToTmpDirFunc: func(prefix string, url string, reference plumbing.ReferenceName) (s string, repository *git.Repository, err error) {
+		currentDir, err := os.Getwd()
+		if err != nil {
+			return "", nil, err
+		}
+		return initRepoFromTestDirRhoamManifest("test-create-manifest-", path.Join(currentDir, "testdata/createProdsecManifestTest"))
+	}}
+
+	pushService := &mockGitPushService{pushFunc: func(gitRepo *git.Repository, opts *git.PushOptions) error {
+		return nil
+	}}
+
+	prService := mockPullRequestsService{
+		ListFunc: func(ctx context.Context, owner string, repo string, opts *github.PullRequestListOptions) (requests []*github.PullRequest, response *github.Response, err error) {
+			return []*github.PullRequest{}, nil, nil
+		},
+		CreateFunc: func(ctx context.Context, owner string, repo string, pull *github.NewPullRequest) (request *github.PullRequest, response *github.Response, err error) {
+			url := "http://testurl"
+			return &github.PullRequest{
+				HTMLURL: &url,
+			}, nil, nil
+		},
+	}
+
+	return &createProdsecManifestCmd{
+		version:         version,
+		repoInfo:        &githubRepoInfo{owner: "test", repo: "test"},
+		baseBranch:      "master",
+		manifestScript:  "prodsec-manifest-generator.sh",
+		gitUser:         "testuser",
+		gitPass:         "testpass",
+		gitCloneService: cloneService,
+		gitPushService:  pushService,
+		githubPRService: prService,
+	}
+}
+
+func verificationFunction(repoDir string, filePath string) error {
+	repo, err := git.PlainOpen(repoDir)
+	if err != nil {
+		return err
+	}
+	repoTree, err := repo.Worktree()
+	if err != nil {
+		return err
+	}
+	status, err := repoTree.Status()
+	if err != nil {
+		return err
+	}
+	if len(status) > 0 {
+		return fmt.Errorf("there are uncommited changes in the repo: %v", status)
+	}
+
+	content, err := ioutil.ReadFile(path.Join(repoDir, filePath))
+	if err != nil {
+		return err
+	}
+	if strings.Index(string(content), "dummy manifest dependency") < 0 {
+		return fmt.Errorf("expected: %s, but got %s", "dummy manifest dependency", string(content))
+	}
+	return nil
+}
+
+func TestCreateRhoamManifestRelease(t *testing.T) {
+	cases := []struct {
+		description string
+		cmd         func() *createProdsecManifestCmd
+		expectError bool
+		filePath    string
+		verify      func(repoDir string, fileLocation string) error
+	}{
+		{
+			description: "should successfully generate the correct manifest for RHMI",
+			cmd: func() *createProdsecManifestCmd {
+				return newTestCreateProdsecManifestCmd("integreatly-operator")
+			},
+			filePath:    "prodsec-manifests/rhmi-production-release-manifest.txt",
+			expectError: false,
+			verify:      verificationFunction,
+		},
+		{
+			description: "should successfully generate the correct manifest for RHOAM",
+			cmd: func() *createProdsecManifestCmd {
+				return newTestCreateProdsecManifestCmd("managed-api-service")
+			},
+			filePath:    "prodsec-manifests/rhoam-production-release-manifest.txt",
+			expectError: false,
+			verify:      verificationFunction,
+		},
+	}
+
+	for _, c := range cases {
+		cmd := c.cmd()
+		repo, err := cmd.run(context.TODO())
+		if repo != "" {
+			defer os.RemoveAll(repo)
+		}
+		if c.expectError && err == nil {
+			t.Fatalf("error expected but it is nil")
+		} else if !c.expectError && err != nil {
+			t.Fatalf("error should be nil but got %v", err)
+		}
+		if c.verify != nil {
+			if err = c.verify(repo, c.filePath); err != nil {
+				t.Fatalf("verification failed due to error: %v", err)
+			}
+		}
+	}
+}
+
+func initRepoFromTestDirRhoamManifest(prefix string, testDir string) (string, *git.Repository, error) {
+	dir, err := ioutil.TempDir(os.TempDir(), prefix)
+	if err != nil {
+		return "", nil, err
+	}
+
+	err = utils.CopyDirectory(testDir, dir)
+	if err != nil {
+		return "", nil, err
+	}
+
+	repo, err := git.PlainInit(dir, false)
+	if err != nil {
+		return "", nil, err
+	}
+
+	tree, err := repo.Worktree()
+	if err != nil {
+		return "", nil, err
+	}
+
+	err = tree.AddGlob(".")
+	if err != nil {
+		return "", nil, err
+	}
+
+	_, err = tree.Commit("initial commit", &git.CommitOptions{
+		Author: &object.Signature{},
+	})
+	if err != nil {
+		return "", nil, err
+	}
+
+	if err := checkoutBranch(tree, false, true, "release-v1.0"); err != nil {
+		return "", nil, err
+	}
+
+	if err := checkoutBranch(tree, false, true, "rhoam-release-v1.0"); err != nil {
+		return "", nil, err
+	}
+
+	if err := checkoutBranch(tree, false, false, "master"); err != nil {
+		return "", nil, err
+	}
+
+	return dir, repo, nil
+}

--- a/cmd/testdata/createProdsecManifestTest/prodsec-manifest-generator.sh
+++ b/cmd/testdata/createProdsecManifestTest/prodsec-manifest-generator.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Dependencies used
+
+
+case $OLM_TYPE in
+  "integreatly-operator")
+    echo "dummy manifest dependency" > "prodsec-manifests/rhmi-production-release-manifest.txt"
+    ;;
+  "managed-api-service")
+    echo "dummy manifest dependency" > "prodsec-manifests/rhoam-production-release-manifest.txt"
+    ;;
+   *)
+    echo "Invalid OLM_TYPE set"
+    echo "Use \"integreatly-operator\" or \"managed-api-service\""
+    exit 1
+    ;;
+esac

--- a/cmd/testdata/createProdsecManifestTest/prodsec-manifests/mock-manifest-example.txt
+++ b/cmd/testdata/createProdsecManifestTest/prodsec-manifests/mock-manifest-example.txt
@@ -1,0 +1,1 @@
+rhoam-manifests/VERSION-manifest.txt

--- a/cmd/testdata/createRhoamManifestTest/rhoam-manifests/mock-manifest-example.txt
+++ b/cmd/testdata/createRhoamManifestTest/rhoam-manifests/mock-manifest-example.txt
@@ -1,0 +1,1 @@
+rhoam-manifests/VERSION-manifest.txt

--- a/pkg/utils/rhmi_version.go
+++ b/pkg/utils/rhmi_version.go
@@ -6,7 +6,11 @@ import (
 	"strings"
 )
 
-const releaseBranchNameTemplate = "prepare-for-release-%s"
+const (
+	releaseBranchNameTemplate = "prepare-for-release-%s"
+	rhoamManifestNameTemplate = "rhoam-manifest-for-release-%s"
+	rhmiManifestNameTemplate  = "rhmi-manifest-for-release-%s"
+)
 
 // RHMIVersion rappresents an integreatly version composed by a base part (2.0.0, 2.0.1, ...)
 // and a build part (ER1, RC2, ..) if it's a prerelase version
@@ -148,6 +152,17 @@ func (v *RHMIVersion) PrepareReleaseBranchName() string {
 	return fmt.Sprintf(releaseBranchNameTemplate, v.TagName())
 }
 
+func (v *RHMIVersion) PrepareProdsecManifestBranchName() string {
+	switch v.olmType {
+	case types.OlmTypeRhmi:
+		return fmt.Sprintf(rhmiManifestNameTemplate, v.TagName())
+	case types.OlmTypeRhoam:
+		return fmt.Sprintf(rhoamManifestNameTemplate, v.TagName())
+	default:
+		return fmt.Sprintf(rhmiManifestNameTemplate, v.TagName())
+	}
+}
+
 func (v *RHMIVersion) IsPatchRelease() bool {
 	return v.patch != "0"
 }
@@ -164,4 +179,15 @@ func (v *RHMIVersion) ReleaseBranchImageTag() string {
 
 func (v *RHMIVersion) OlmType() string {
 	return v.olmType
+}
+
+func (v *RHMIVersion) NameByOlmType() string {
+	switch v.olmType {
+	case types.OlmTypeRhmi:
+		return "rhmi"
+	case types.OlmTypeRhoam:
+		return "rhoam"
+	default:
+		return "rhmi"
+	}
 }

--- a/pkg/utils/rhmi_version_test.go
+++ b/pkg/utils/rhmi_version_test.go
@@ -171,3 +171,63 @@ func TestRHMIVersion_MajorMinor(t *testing.T) {
 		})
 	}
 }
+
+func TestNameByOlmType(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		olmType string
+	}{
+		{
+			name:    "test that managed-api-service returns rhoam",
+			olmType: "managed-api-service",
+			version: "1.1.0",
+			want:    "rhoam",
+		},
+		{
+			name:    "test that integreatly-operaotr returns rhmi",
+			version: "2.7.0",
+			olmType: "integreatly-operator",
+			want:    "rhmi",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, _ := NewVersion(tt.version, tt.olmType)
+			if got := v.NameByOlmType(); got != tt.want {
+				t.Errorf("NameByOlmType = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrepareProdsecManifestBranchName(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    string
+		olmType string
+	}{
+		{
+			name:    "test that managed-api-service returns rhoam",
+			olmType: "managed-api-service",
+			version: "1.1.0",
+			want:    "rhoam-manifest-for-release-rhoam-v1.1.0",
+		},
+		{
+			name:    "test that integreatly-operaotr returns rhmi",
+			version: "2.7.0",
+			olmType: "integreatly-operator",
+			want:    "rhmi-manifest-for-release-v2.7.0",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, _ := NewVersion(tt.version, tt.olmType)
+			if got := v.PrepareProdsecManifestBranchName(); got != tt.want {
+				t.Errorf("NameByOlmType = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Changes related to https://issues.redhat.com/browse/MGDAPI-304

Do not merge - manifest generation script must be updated first

To verify changes:
Run from this repo
- make build/cli
- update the "DefaultIntegreatlyGithubOrg" to your github org in root.go file
- make sure that your local branch of integreatly operator is up to date
- generate new client access token
- export GITHUB_TOKEN=<YOUR ACCESS TOKEN>
- export GITHUB_USER=<YOUR USER NAME> 
- ./delorean release create-rhoam-manifest --version=1.1.0 --olmType=managed-api-service --branch=master

Verify that a new PR has been submitted against your branch with name `rhoam-manifest-for-release-rhoam-1.1.0`
NOTE: updates to the actual script call might be made later on, once scripts in the integreatly repo got updated.