### PR TITLE
fix: service affecting flag

### DIFF
--- a/cmd/createRelease.go
+++ b/cmd/createRelease.go
@@ -3,6 +3,12 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+	"time"
+
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -11,11 +17,6 @@ import (
 	"github.com/integr8ly/delorean/pkg/services"
 	"github.com/integr8ly/delorean/pkg/utils"
 	"github.com/spf13/cobra"
-	"os"
-	"os/exec"
-	"path"
-	"strings"
-	"time"
 )
 
 type createReleaseCmdFlags struct {
@@ -146,8 +147,10 @@ func (c *createReleaseCmd) runReleaseScript(repoDir string) error {
 		return err
 	}
 	envs := []string{fmt.Sprintf("SEMVER=%s", c.version.String()), fmt.Sprintf("OLM_TYPE=%s", c.version.OlmType())}
-	if !c.serviceAffecting {
-		envs = append(envs, "NON_SERVICE_AFFECTING=true")
+	if c.serviceAffecting {
+		envs = append(envs, "SERVICE_AFFECTING=true")
+	} else {
+		envs = append(envs, "SERVICE_AFFECTING=false")
 	}
 	releaseScript := &exec.Cmd{Dir: repoDir, Env: envs, Path: c.releaseScript, Stdout: os.Stdout, Stderr: os.Stderr}
 	return releaseScript.Run()

--- a/cmd/testdata/createReleaseTest/release.sh
+++ b/cmd/testdata/createReleaseTest/release.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-echo $SEMVER > VERSION.txt
-if [[ ! -z "$NON_SERVICE_AFFECTING" ]]; then
+echo "$SEMVER" > VERSION.txt
+if [[ "$SERVICE_AFFECTING" == true ]]; then
+ echo "ServiceAffecting=true" >> VERSION.txt
+else
  echo "ServiceAffecting=false" >> VERSION.txt
 fi


### PR DESCRIPTION
### JIRA
MGDAPI-1073

### Comments
* this PR depends on https://github.com/integr8ly/integreatly-operator/pull/1542 (that PR branch is used for the verification below)

### Verification

Verified locally (see `Update CSV for release 1.99.0-rc1` messages)
```bash
# Test serviceAffecting: false
[fedora@rate-limit-testing delorean]$ ./delorean release create-release --owner=psturc --repo=integreatly-operator --branch=MGDAPI-1073 --version=1.99.0-rc1 --serviceAffecting=false --olmType managed-api-service --user <hidden> --token <hidden>
Clone repo from https://github.com/psturc/integreatly-operator.git to a temporary directory
Enumerating objects: 24, done.
Counting objects: 100% (24/24), done.
Compressing objects: 100% (20/20), done.
Total 55630 (delta 10), reused 10 (delta 4), pack-reused 55606
Repo cloned to /tmp/integreatly-operator406022428
Checkout branch prepare-for-release-rhoam-v1.99.0-rc1
Invoke release script: scripts/prepare-release.sh
Valid version string: 1.99.0-rc1
INFO[0000] Generating CSV manifest version 1.99.0
INFO[0000] Created deploy/olm-catalog/managed-api-service/1.99.0/managed-api-service.v1.99.0.clusterserviceversion.yaml
Updating descriptions
Updating permissions
Update CSV for release 1.99.0-rc1 to be 'serviceAffecting: false'
Commit new changes
^C
# Get the serviceAffecting field value with yq:
[fedora@rate-limit-testing delorean]$ VAR_FOLDER=/tmp/integreatly-operator406022428
[fedora@rate-limit-testing delorean]$ yq r $VAR_FOLDER/deploy/olm-catalog/managed-api-service/1.99.0/managed-api-service.v1.99.0.clusterserviceversion.yaml 'metadata.annotations.serviceAffecting'
false

# Test serviceAffecting: true
[fedora@rate-limit-testing delorean]$ ./delorean release create-release --owner=psturc --repo=integreatly-operator --branch=MGDAPI-1073 --version=1.99.0-rc1 --serviceAffecting=true --olmType managed-api-service --user <hidden> --token <hidden>
Clone repo from https://github.com/psturc/integreatly-operator.git to a temporary directory
Enumerating objects: 24, done.
Counting objects: 100% (24/24), done.
Compressing objects: 100% (20/20), done.
Total 55630 (delta 10), reused 10 (delta 4), pack-reused 55606
Repo cloned to /tmp/integreatly-operator314512527
Checkout branch prepare-for-release-rhoam-v1.99.0-rc1
Invoke release script: scripts/prepare-release.sh
Valid version string: 1.99.0-rc1
INFO[0000] Generating CSV manifest version 1.99.0
INFO[0000] Created deploy/olm-catalog/managed-api-service/1.99.0/managed-api-service.v1.99.0.clusterserviceversion.yaml
Updating descriptions
Updating permissions
Update CSV for release 1.99.0-rc1 to be 'serviceAffecting: true'
Commit new changes
^C
# Get the serviceAffecting field value with yq:
[fedora@rate-limit-testing delorean]$ VAR_FOLDER=/tmp/integreatly-operator314512527
[fedora@rate-limit-testing delorean]$ yq r $VAR_FOLDER/deploy/olm-catalog/managed-api-service/1.99.0/managed-api-service.v1.99.0.clusterserviceversion.yaml 'metadata.annotations.serviceAffecting'
true
```