### PR TITLE
fix: cleanup config for rhoam s3 bucket

### DIFF
--- a/configurations/cleanup-reports.yaml
+++ b/configurations/cleanup-reports.yaml
@@ -10,3 +10,13 @@ configs:
     tags:
       - key: datahub
         value: true
+  - bucket: rhoam-test-data-storage-4mk5
+    tags:
+      - key: polarion
+        value: true
+      - key: rp
+        value: true
+  - bucket: rhoam-test-data-storage-4mk5
+    tags:
+      - key: datahub
+        value: true


### PR DESCRIPTION
### Description

Cleanup config for the nightly job for importing test results from RHOAM pipelines
https://master-jenkins-csb-intly.cloud.paas.psi.redhat.com/job/Nightly/job/rhoam-import-testing-results/2/console

I created a separate s3 bucket for RHOAM results, so it's easier to manage.

### Verification

Verified with
```bash
./delorean report cleanup --config-file=configurations/cleanup-reports.yaml
...
[rhoam-test-data-storage-4mk5] Object nightly-managed-api-install-multi-2021-02-24-06-25-09.zip copied to archive/nightly-managed-api-install-multi-2021-02-24-06-25-09.zip
[rhoam-test-data-storage-4mk5] Copied 47 objects to archive
[rhoam-test-data-storage-4mk5] Deleting 47 objects
[rhoam-test-data-storage-4mk5] 47 objects deleted
[All] Process completed
```