### PR TITLE
[MGDAPI-1349] Updated prow config version

### DIFF
--- a/cmd/openshiftCIAddBranch.go
+++ b/cmd/openshiftCIAddBranch.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	ProwConfigSourceRHMI   = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.0.yaml"
-	ProwConfigSourceRHOAM  = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.1.yaml"
+	ProwConfigSourceRHOAM  = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.3.yaml"
 	ProwConfigSourceMaster = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml"
 	ProwInternalRegistry   = "registry.ci.openshift.org/integr8ly"
 )


### PR DESCRIPTION
## What 
updated what config file is used to generate prow checks 

## Why 
https://issues.redhat.com/browse/MGDAPI-1349
To include checks for files generated by the kubebuilder 