### PR TITLE
Fixed namespace names for RHOAM downtime report

### DIFF
--- a/configurations/downtime-report-config-rhoam.yaml
+++ b/configurations/downtime-report-config-rhoam.yaml
@@ -7,44 +7,44 @@ queries:
   # 3scale related dowmtime metrics. For k8s endpoints, it assumes that the service is down when the kube_endpoint_address_available value is 0
   - name: 3scale_apicast_production_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-production', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-production', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_apicast_staging_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-staging', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='apicast-staging', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_system_developer_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-developer', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-developer', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_system_master_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-master', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-master', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_system_memcache_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-memcache', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-memcache', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_system_provider_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-provider', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-provider', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_system_sphinx_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-sphinx', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='system-sphinx', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_zync_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_zync_database_provider_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync-database', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='zync-database', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_backend_listener_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='backend-listener', namespace='redhat-rhmi-3scale'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='backend-listener', namespace='redhat-rhoam-3scale'} , 1)[$duration:30s]) * $range)/1000"
   - name: 3scale_workload_app_downtime_seconds
     type: query
     query: "sum(workload_app_service_downtime_seconds{name='3scale_service'})"
   # rhssouser related downtime metrics
   - name: rhssouser_keycloak_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhmi-user-sso'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhoam-user-sso'} , 1)[$duration:30s]) * $range)/1000"
   - name: rhssouser_keycloak_discovery_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhmi-user-sso'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhoam-user-sso'} , 1)[$duration:30s]) * $range)/1000"
   - name: rhssouser_ui_blackbox_downtime_seconds
     type: query
     query: "$range - (probe_success{service='rhssouser-ui'} * $range)"
@@ -54,10 +54,10 @@ queries:
   # rhsso related downtime metrics
   - name: rhsso_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhmi-sso'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhoam-sso'} , 1)[$duration:30s]) * $range)/1000"
   - name: rhsso_keycloak_discovery_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhmi-sso'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhoam-sso'} , 1)[$duration:30s]) * $range)/1000"
   - name: rhsso_ui_blackbox_downtime_seconds
     type: query
     query: "$range - (probe_success{service='rhsso-ui'} * $range)"


### PR DESCRIPTION
Fixed namespace names for RHOAM downtime report. Just simple replace of 'rhmi' with 'rhoam'.

**Verification steps**
Eye review probably sufficient.
Otherwise you need to have a cluster, deploy workload web app, and generate the downtime report like this:
- cd delorean
- make build/cli
- ./delorean pipeline query-report --namespace redhat-rhoam-middleware-monitoring-operator --config-file ./configurations/downtime-report-config-rhoam.yaml -o <output_dir>

See the generated json file, it should contain `metrics` and `value` in each `result`, definitely it should not contian `result: []`

I validated this when doing https://issues.redhat.com/browse/MGDAPI-1071