### PR TITLE
ocm: feat: add check of cluster health status

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -115,6 +115,7 @@ create_cluster() {
     echo "Cluster ID: ${cluster_id}"
 
     wait_for "ocm get /api/clusters_mgmt/v1/clusters/${cluster_id}/status | jq -r .state | grep -q ready" "cluster creation" "180m" "300"
+    wait_for "ocm get /api/clusters_mgmt/v1/clusters/${cluster_id} | jq -r .health_state | grep -q healthy" "cluster to be healthy" "30m" "30"
     wait_for "ocm get /api/clusters_mgmt/v1/clusters/${cluster_id}/credentials | jq -r .admin | grep -q admin" "fetching cluster credentials" "10m" "30"
 
     save_cluster_credentials "${cluster_id}"


### PR DESCRIPTION
https://issues.redhat.com/browse/MGDAPI-1453

### Verification
```
➜  delorean git:(MGDAPI-1453) make ocm/cluster/create                                  
Sending a request to OCM to create an OSD cluster
Cluster ID: <HIDDEN>
Waiting for cluster creation for 180m...
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
Waiting for cluster creation... Trying again in 300s
cluster creation finished!
Waiting for cluster to be healthy for 30m...
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
Waiting for cluster to be healthy... Trying again in 30s
cluster to be healthy finished!
Waiting for fetching cluster credentials for 10m...
fetching cluster credentials finished!
Login credentials:
...
```