### PR TITLE
Manifest generation update

### DIFF
--- a/cmd/createProdsecManifest_test.go
+++ b/cmd/createProdsecManifest_test.go
@@ -15,7 +15,7 @@ import (
 	"testing"
 )
 
-func newTestCreateProdsecManifestCmd(olmType string) *createProdsecManifestCmd {
+func newTestCreateProdsecManifestCmd(olmType string, typeOfManifest string) *createProdsecManifestCmd {
 	version, _ := utils.NewVersion("1.0.0", olmType)
 
 	// Clone and initiate the mock integreatly repo from testdata/createRhoamManifest
@@ -48,6 +48,7 @@ func newTestCreateProdsecManifestCmd(olmType string) *createProdsecManifestCmd {
 		repoInfo:        &githubRepoInfo{owner: "test", repo: "test"},
 		baseBranch:      "master",
 		manifestScript:  "prodsec-manifest-generator.sh",
+		typeOfManifest:  typeOfManifest,
 		gitUser:         "testuser",
 		gitPass:         "testpass",
 		gitCloneService: cloneService,
@@ -94,7 +95,7 @@ func TestCreateRhoamManifestRelease(t *testing.T) {
 		{
 			description: "should successfully generate the correct manifest for RHMI",
 			cmd: func() *createProdsecManifestCmd {
-				return newTestCreateProdsecManifestCmd("integreatly-operator")
+				return newTestCreateProdsecManifestCmd("integreatly-operator", "production")
 			},
 			filePath:    "prodsec-manifests/rhmi-production-release-manifest.txt",
 			expectError: false,
@@ -103,11 +104,43 @@ func TestCreateRhoamManifestRelease(t *testing.T) {
 		{
 			description: "should successfully generate the correct manifest for RHOAM",
 			cmd: func() *createProdsecManifestCmd {
-				return newTestCreateProdsecManifestCmd("managed-api-service")
+				return newTestCreateProdsecManifestCmd("managed-api-service", "production")
 			},
 			filePath:    "prodsec-manifests/rhoam-production-release-manifest.txt",
 			expectError: false,
 			verify:      verificationFunction,
+		},
+		{
+			description: "should successfully generate the correct master manifest for RHMI",
+			cmd: func() *createProdsecManifestCmd {
+				return newTestCreateProdsecManifestCmd("integreatly-operator", "master")
+			},
+			filePath:    "prodsec-manifests/rhmi-master-manifest.txt",
+			expectError: false,
+			verify:      verificationFunction,
+		},
+		{
+			description: "should successfully generate the correct master manifest for RHOAM",
+			cmd: func() *createProdsecManifestCmd {
+				return newTestCreateProdsecManifestCmd("managed-api-service", "master")
+			},
+			filePath:    "prodsec-manifests/rhoam-master-manifest.txt",
+			expectError: false,
+			verify:      verificationFunction,
+		},
+		{
+			description: "RHOAM compare manifest should return 1",
+			cmd: func() *createProdsecManifestCmd {
+				return newTestCreateProdsecManifestCmd("managed-api-service", "compare")
+			},
+			expectError: true,
+		},
+		{
+			description: "RHMI compare manifest should return 0",
+			cmd: func() *createProdsecManifestCmd {
+				return newTestCreateProdsecManifestCmd("integreatly-operator", "compare")
+			},
+			expectError: false,
 		},
 	}
 

--- a/cmd/testdata/createProdsecManifestTest/prodsec-manifest-generator.sh
+++ b/cmd/testdata/createProdsecManifestTest/prodsec-manifest-generator.sh
@@ -1,14 +1,36 @@
 #!/usr/bin/env bash
 
 # Dependencies used
-
+case $TYPE_OF_MANIFEST in 
+  "production")
+  RHMIfileName="rhmi-production-release-manifest.txt"
+  RHOAMfileName="rhoam-production-release-manifest.txt"
+  ;;
+  "master")
+  RHMIfileName="rhmi-master-manifest.txt"
+  RHOAMfileName="rhoam-master-manifest.txt"
+  ;;
+  "compare")
+    case $OLM_TYPE in
+      "integreatly-operator")
+        exit 0
+        ;;
+      "managed-api-service")
+        exit 1
+        ;;
+       *)
+        ;;
+      esac
+  ;;
+  *)
+esac
 
 case $OLM_TYPE in
   "integreatly-operator")
-    echo "dummy manifest dependency" > "prodsec-manifests/rhmi-production-release-manifest.txt"
+    echo "dummy manifest dependency" > "prodsec-manifests/$RHMIfileName"
     ;;
   "managed-api-service")
-    echo "dummy manifest dependency" > "prodsec-manifests/rhoam-production-release-manifest.txt"
+    echo "dummy manifest dependency" > "prodsec-manifests/$RHOAMfileName"
     ;;
    *)
     echo "Invalid OLM_TYPE set"

--- a/cmd/testdata/createRhoamManifestTest/rhoam-manifests/mock-manifest-example.txt
+++ b/cmd/testdata/createRhoamManifestTest/rhoam-manifests/mock-manifest-example.txt
@@ -1,1 +1,0 @@
-rhoam-manifests/VERSION-manifest.txt


### PR DESCRIPTION
Jira - https://issues.redhat.com/browse/MGDAPI-1371

## What
Added support for following commands
1. Production manifest generation for RHOAM/RHMI
`./delorean release create-prodsec-manifest --owner={OWNER} --repo={REPO} --version={VERSION} --branch={BRANCH} --olmType={OLM_TYPE} --typeOfManifest=production`
2. Master manifest generation for RHOAM/RHMI
`./delorean release create-prodsec-manifest --owner={OWNER} --repo={REPO} --branch={BRANCH} --olmType={OLM_TYPE} --typeOfManifest=master`
3. Compare current manifests for RHOAM/RHMI
`./delorean release create-prodsec-manifest --owner={OWNER} --repo={REPO} --branch={BRANCH} --olmType={OLM_TYPE} --typeOfManifest=compare`

## Verification
- As this change involves 4 repos please reach out to me to guide me through the verification or:

- update your own fork master branch of intly operator to match whats in this pr - https://github.com/integr8ly/integreatly-operator/pull/1686
- export GITHUB_USER=your username
- export GITHUB_TOKEN=your token (done via creating oauth token in github - follow these instructions https://docs.github.com/en/github/authenticating-to-github/creating-a-personal-access-token) 
- run above commands with following vars:
owner = your github account name
repo = integreatly-operator
olmType = either managed-api-service or integreatly-operator


