### PR TITLE
MGDAPI-1496 Change all references of Managed Tenants master to main

### DIFF
--- a/cmd/osdAddonRelease_test.go
+++ b/cmd/osdAddonRelease_test.go
@@ -85,7 +85,9 @@ func initRepoFromTestDir(prefix string, testDir string) (string, *git.Repository
 	if err != nil {
 		return "", nil, err
 	}
-
+	if err := checkoutBranch(tree, false, true, "main"); err != nil {
+		return "", nil, err
+	}
 	return dir, repo, nil
 }
 
@@ -169,13 +171,13 @@ func TestOSDAddonRelease(t *testing.T) {
 			// Prepare the integreatly-operator directory
 			integreatlyOperatorDir := path.Join(basedir, fmt.Sprintf("testdata/osdAddonReleaseIntegreatlyOperator%s", version))
 
-			// Prepare the managed-teneants repo and dir
+			// Prepare the managed-tenants repo and dir
 			managedTenantsDir, managedTenantsRepo := prepareManagedTenants(t, basedir)
 
 			// Mock the push service
 			mockPushService := &mockGitPushService{pushFunc: func(gitRepo *git.Repository, opts *git.PushOptions) error {
 				// Save the last commit diff before HEAD get reset to master
-				managedTenantsPatch = gitDiff(t, managedTenantsRepo, "master", "HEAD")
+				managedTenantsPatch = gitDiff(t, managedTenantsRepo, "main", "HEAD")
 
 				managedTenantsRepoPushed = true
 				return nil
@@ -312,11 +314,11 @@ func TestOSDAddonRelease(t *testing.T) {
 						t.Fatalf("expected 1 but found %d chunk changes for %s", found, clusterServiceVersion)
 					}
 					if found := p.Chunks()[0].Type(); found != diff.Add {
-						t.Fatalf("the frist and only chunk type should be Add but found %d for %s", found, clusterServiceVersion)
+						t.Fatalf("the first and only chunk type should be Add but found %d for %s", found, clusterServiceVersion)
 					}
 					content := p.Chunks()[0].Content()
 					if found := len(content); found <= 0 {
-						t.Fatalf("expected %s to be largern then 0 but found %d", clusterServiceVersion, found)
+						t.Fatalf("expected %s to be larger than 0 but found %d", clusterServiceVersion, found)
 					}
 					csv := &olmapiv1alpha1.ClusterServiceVersion{}
 					err := yaml.Unmarshal([]byte(content), csv)
@@ -356,10 +358,10 @@ func TestOSDAddonRelease(t *testing.T) {
 						t.Fatalf("expected 1 but found %d chunk changes for %s", found, customResourceDefinition)
 					}
 					if found := p.Chunks()[0].Type(); found != diff.Add {
-						t.Fatalf("the frist and only chunk type should be Add but found %d for %s", found, customResourceDefinition)
+						t.Fatalf("the first and only chunk type should be Add but found %d for %s", found, customResourceDefinition)
 					}
 					if found := len(p.Chunks()[0].Content()); found <= 0 {
-						t.Fatalf("expected %s to be largern then 0 but found %d", customResourceDefinition, found)
+						t.Fatalf("expected %s to be larger than 0 but found %d", customResourceDefinition, found)
 					}
 				default:
 					t.Fatalf("unexpected file %s", file.Path())
@@ -372,8 +374,8 @@ func TestOSDAddonRelease(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			if founded := head.Name(); founded != "refs/heads/master" {
-				t.Fatalf("the managed-tenants repo HEAD doesn't point to the master branch\nexpected: refs/heads/master\nfounded: %s", founded)
+			if founded := head.Name(); founded != "refs/heads/main" {
+				t.Fatalf("the managed-tenants repo HEAD doesn't point to the main branch\nexpected: refs/heads/main\nfounded: %s", founded)
 			}
 		})
 	}

--- a/cmd/osdAddonRelease_test.go
+++ b/cmd/osdAddonRelease_test.go
@@ -173,11 +173,13 @@ func TestOSDAddonRelease(t *testing.T) {
 
 			// Prepare the managed-tenants repo and dir
 			managedTenantsDir, managedTenantsRepo := prepareManagedTenants(t, basedir)
+			var managedTenantsMainBranch string = "main"
+			var managedTenantsRef plumbing.ReferenceName = "refs/heads/main"
 
 			// Mock the push service
 			mockPushService := &mockGitPushService{pushFunc: func(gitRepo *git.Repository, opts *git.PushOptions) error {
 				// Save the last commit diff before HEAD get reset to master
-				managedTenantsPatch = gitDiff(t, managedTenantsRepo, "main", "HEAD")
+				managedTenantsPatch = gitDiff(t, managedTenantsRepo, managedTenantsMainBranch, "HEAD")
 
 				managedTenantsRepoPushed = true
 				return nil
@@ -368,13 +370,13 @@ func TestOSDAddonRelease(t *testing.T) {
 				}
 			}
 
-			// Verify the manage-tenents repo HEAD is pointing to master
+			// Verify the manage-tenents repo HEAD is pointing to main
 			head, err := managedTenantsRepo.Head()
 			if err != nil {
 				t.Fatal(err)
 			}
 
-			if founded := head.Name(); founded != "refs/heads/main" {
+			if founded := head.Name(); founded != managedTenantsRef {
 				t.Fatalf("the managed-tenants repo HEAD doesn't point to the main branch\nexpected: refs/heads/main\nfounded: %s", founded)
 			}
 		})


### PR DESCRIPTION
# What
Change all references to master in addon release function to main.
# Why
Managed Tenants repo is switching default branch from master to main on April 8th.
# Verification
### Prerequisites:
Forks of integreatly-operator, delorean and managed-tenants repositories
### Steps: 

- Create a main branch and set it as default branch on your fork of managed tenants, I followed this guide: https://boleary.dev/blog/2020-06-11-change-your-default-branch.html
- Go to your fork of managed-tenants on gitlab and add a remote access token with full permissions to the repository
- Create a github oAuth token with full permissions from account settings
- Clone your forks of delorean and integreatly-operator (Ensure your forks are up to date)
- In your cloned delorean repo, edit the configurations/managed-tenants-addons-config-rhoam.yaml file to point to your fork of integreatly-operator.
- Build the Delorean CLI
```shell 
make build/cli
 ```
- In the directory where delorean is cloned, prepare a dummy release using the following command:
 ```shell 
./delorean release create-release \
                --owner="yourGithubUsername" \
                --repo="integreatly-operator" \
                --branch="master" \
                --version="1.5.0-rc1" \
                --serviceAffecting="true" \
                --olmType "managed-api-service" \
                --user 'yourGithubUsername' \
                --token 'yourGithubAccessToken'
```
- This should create a pr for our dummy release on your fork of the integreatly-operator.
- Run the following command to merge this PR: 
```shell
./delorean release merge-release \
                --owner="yourGithubUsername" \
                --repo="integreatly-operator" \
                --branch="master" \
                --version="1.5.0-rc1" \
                --olmType "managed-api-service \
                --user 'yourGithubUsername' \
                --token 'yourGithubAccessToken'
```
- Run the following command to make an MR against your fork of managed-tenants
```shell 
./delorean release osd-addon \                           
                --channel 'stage' \
                --version '1.5.0-rc1' \
                --managed-tenants-origin 'yourGitlabUsername/managed-tenants' \
                --managed-tenants-fork 'yourGitlabUsername/managed-tenants' \
                --name 'managed-api-service' \
                --addons-config '/yourPathToClonedDelorean/delorean/configurations/managed-tenants-addons-config-rhoam.yaml' \
                --olmType 'managed-api-service' \
                --gitlab-token 'yourGitlabToken'
```

- Once this command is run an MR should be created against your fork of managed tenants, you may also wish to try running the release osd-addon against existing releases by deleting the corresponding bundle on your managed tenants fork and ensuring the bundle is added back once the command is run.