### PR TITLE
Manifest generator - update to the generated PR name

### DIFF
--- a/cmd/createProdsecManifest.go
+++ b/cmd/createProdsecManifest.go
@@ -242,6 +242,15 @@ func (c *createProdsecManifestCmd) commitAndPushChanges(gitRepo *git.Repository,
 }
 
 func (c *createProdsecManifestCmd) createPRIfNotExists(ctx context.Context, releaseBranchName string) error {
+	var typeOfInstallation string
+	switch c.version.OlmType() {
+	case "integreatly-operator":
+		typeOfInstallation = "RHMI"
+	case "managed-api-service":
+		typeOfInstallation = "RHOAM"
+	default:
+		typeOfInstallation = "RHOAM"
+	}
 	h := fmt.Sprintf("%s:%s", c.repoInfo.owner, releaseBranchName)
 	prOpts := &github.PullRequestListOptions{Base: c.baseBranch.String(), Head: h}
 	pr, err := findPRForRelease(ctx, c.githubPRService, c.repoInfo, prOpts)
@@ -249,7 +258,7 @@ func (c *createProdsecManifestCmd) createPRIfNotExists(ctx context.Context, rele
 		return err
 	}
 	if pr == nil {
-		t := fmt.Sprintf("Manifest PR for %s for %s manifest", c.version.OlmType(), c.typeOfManifest)
+		t := fmt.Sprintf("Update to %s %s manifest", typeOfInstallation, c.typeOfManifest)
 		b := c.baseBranch.String()
 		req := &github.NewPullRequest{
 			Title: &t,


### PR DESCRIPTION
An update to the name of generated by the manifest generator command PR.
Previous name:
![image](https://user-images.githubusercontent.com/43473912/116696161-71e7e980-a9b9-11eb-9cbf-789bef57def7.png)
New name:
![image](https://user-images.githubusercontent.com/43473912/116696186-7ca27e80-a9b9-11eb-8bbf-12ced9d8b569.png)

Verification
- make sure your fork of integreatly repo is up to date with master
- checkout this branch
- run `make build/cli`
- run `export GITHUB_USER=<YOUR_GITHUB_USERNAME>`
- run `export GITHUB_TOKEN=<YOUR_GITHUB_TOKEN>`
- run `./delorean release create-prodsec-manifest --owner=<YOUR_GITHUB_USERNAME> --repo=integreatly-operator --branch=master --olmType=managed-api-service --typeOfManifest=master`
Confirm that a PR with the appropriate name has been generated.
Alternatively, reach out to me to verify against my own fork.