### PR TITLE
Fixed RHOAM downtime report configuration

### DIFF
--- a/configurations/downtime-report-config-rhoam.yaml
+++ b/configurations/downtime-report-config-rhoam.yaml
@@ -54,10 +54,10 @@ queries:
   # rhsso related downtime metrics
   - name: rhsso_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhoam-sso'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak', namespace='redhat-rhoam-rhsso'} , 1)[$duration:30s]) * $range)/1000"
   - name: rhsso_keycloak_discovery_k8s_endpoint_downtime_seconds
     type: query
-    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhoam-sso'} , 1)[$duration:30s]) * $range)/1000"
+    query: "($range - avg_over_time(clamp_max(kube_endpoint_address_available{endpoint='keycloak-discovery', namespace='redhat-rhoam-rhsso'} , 1)[$duration:30s]) * $range)/1000"
   - name: rhsso_ui_blackbox_downtime_seconds
     type: query
     query: "$range - (probe_success{service='rhsso-ui'} * $range)"


### PR DESCRIPTION
Fixed Cluster SSO namespace name in the downtime report.

Verification Steps
Run the downtime report as mentioned in n02b test case [1]. In the resulted yaml file you should not see `result: []` (empty array) but you should see some `metrics` data there.

Alternative just check the cluster sso namespace name in the RHOAM cluster to validate it matches now.

[1] https://github.com/integr8ly/integreatly-operator/blob/master/test-cases/tests/upgrade/n02b-upgrade-rhoam.md