### PR TITLE
Fix the cluster health check

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -122,7 +122,7 @@ create_cluster() {
     echo "Cluster ID: ${cluster_id}"
 
     wait_for "ocm get /api/clusters_mgmt/v1/clusters/${cluster_id}/status | jq -r .state | grep -q ready" "cluster creation" "${TIMEOUT_CLUSTER_CREATION}m" "300"
-    wait_for "ocm get /api/clusters_mgmt/v1/clusters/${cluster_id} | jq -r .health_state | grep -q healthy" "cluster to be healthy" "${TIMEOUT_CLUSTER_HEALTH_CHECK}m" "30" \
+    wait_for "ocm get subs --parameter search=\"cluster_id = '${cluster_id}'\" | jq -r .items[0].metrics[0].health_state | grep -q healthy" "cluster to be healthy" "${TIMEOUT_CLUSTER_HEALTH_CHECK}m" "30" \
         || echo "${WARNING_CLUSTER_HEALTH_CHECK_FAILED}"
     wait_for "ocm get /api/clusters_mgmt/v1/clusters/${cluster_id}/credentials | jq -r .admin | grep -q admin" "fetching cluster credentials" "10m" "30"
 


### PR DESCRIPTION
Closes https://issues.redhat.com/browse/MGDAPI-1711

Using a new health check metric. The health check was left optional so the pipelines should proceed after 30 minutes even if the cluster's health check does not say 'healthy'.

Verification Steps
I think it is sufficient to review the logs. The pipeline is still in progress but it got through the health check already. It took almost 10 minutes for the health check to pass.
https://master-jenkins-csb-intly.apps.ocp4.prod.psi.redhat.com/job/ManagedAPI/job/managed-api-install-master/1/console

Alternatively you can try the command locally to see it works