### PR TITLE
Remove marking the unstable stages as failures.

### DIFF
--- a/pkg/utils/jenkins.go
+++ b/pkg/utils/jenkins.go
@@ -92,10 +92,9 @@ type PipelineRun struct {
 }
 
 const (
-	TestSuiteName             = "pipeline-status"
-	PipelineRunStatusFailed   = "FAILED"
-	PipelineRunStatusAborted  = "ABORTED"
-	PipelineRunStatusUnstable = "UNSTABLE"
+	TestSuiteName            = "pipeline-status"
+	PipelineRunStatusFailed  = "FAILED"
+	PipelineRunStatusAborted = "ABORTED"
 )
 
 // ToJUnitSuites will convert the status of the pipeline run into JUnit test suites
@@ -146,12 +145,6 @@ func (p *PipelineRun) ToJUnitSuites(filter string) (*JUnitTestSuites, error) {
 				tc.SkipMessage = &JUnitSkipMessage{
 					Message: s.Error.Message,
 				}
-			}
-		case PipelineRunStatusUnstable:
-			ts.Failures++
-			tc.Failure = &JUnitFailure{
-				Message: s.Error.Message,
-				Type:    s.Error.Type,
 			}
 		}
 

--- a/pkg/utils/jenkins_test.go
+++ b/pkg/utils/jenkins_test.go
@@ -11,18 +11,21 @@ func TestPipelineRun_ToJUnitSuites(t *testing.T) {
 		pipelineStatusFile string
 		expectedFailures   int
 		expectedSkips      int
+		expectedTests      int
 	}{
 		{
 			description:        "success",
 			pipelineStatusFile: "./testdata/jenkins/pipeline-status.json",
 			expectedFailures:   1,
 			expectedSkips:      7,
+			expectedTests:      14,
 		},
 		{
 			description:        "Aborted",
 			pipelineStatusFile: "./testdata/jenkins/aborted-pipeline-status.json",
 			expectedFailures:   1,
 			expectedSkips:      6,
+			expectedTests:      15,
 		},
 	}
 
@@ -38,8 +41,8 @@ func TestPipelineRun_ToJUnitSuites(t *testing.T) {
 			if ts.Name != TestSuiteName {
 				t.Fatalf("name doesn't match. expected: %s got: %s", TestSuiteName, ts.Name)
 			}
-			if len(ts.TestCases) != len(p.Stages) {
-				t.Fatalf("number of test cases does't match. expected: %d got: %d", len(p.Stages), len(ts.TestCases))
+			if len(ts.TestCases) != c.expectedTests {
+				t.Fatalf("number of test cases does't match. expected: %d got: %d", c.expectedTests, len(ts.TestCases))
 			}
 			if ts.Failures != c.expectedFailures {
 				t.Fatalf("number of failures doesn't match. expected: %d got: %d", c.expectedFailures, ts.Failures)

--- a/pkg/utils/testdata/jenkins/aborted-pipeline-status.json
+++ b/pkg/utils/testdata/jenkins/aborted-pipeline-status.json
@@ -19,6 +19,20 @@
     {
       "_links": {
         "self": {
+          "href": "/job/Nightly/job/managed-api-rosa/8/execution/node/52/wfapi/describe"
+        }
+      },
+      "id": "52",
+      "name": "Unstable Stage",
+      "execNode": "",
+      "status": "UNSTABLE",
+      "startTimeMillis": 1615838457603,
+      "durationMillis": 61,
+      "pauseDurationMillis": 0
+    },
+    {
+      "_links": {
+        "self": {
           "href": "/job/Nightly/job/managed-api-rosa/8/execution/node/16/wfapi/describe"
         }
       },

--- a/pkg/utils/testdata/jenkins/pipeline-status.json
+++ b/pkg/utils/testdata/jenkins/pipeline-status.json
@@ -19,6 +19,20 @@
     {
       "_links": {
         "self": {
+          "href": "/job/Nightly/job/managed-api-rosa/8/execution/node/52/wfapi/describe"
+        }
+      },
+      "id": "52",
+      "name": "Unstable Stage",
+      "execNode": "",
+      "status": "UNSTABLE",
+      "startTimeMillis": 1615838457603,
+      "durationMillis": 61,
+      "pauseDurationMillis": 0
+    },
+    {
+      "_links": {
+        "self": {
           "href": "/job/Nightly/job/rhmi-install-addon-flow/131/execution/node/16/wfapi/describe"
         }
       },


### PR DESCRIPTION
This is to address the extra work in ReportPortal caused by adding the extra failure marker.