### PR TITLE
update to latest prow config

### DIFF
--- a/cmd/openshiftCIAddBranch.go
+++ b/cmd/openshiftCIAddBranch.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	ProwConfigSourceRHMI   = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.0.yaml"
-	ProwConfigSourceRHOAM  = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.3.yaml"
+	ProwConfigSourceRHMI   = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.8.yaml"
+	ProwConfigSourceRHOAM  = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.7.yaml"
 	ProwConfigSourceMaster = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml"
 	ProwInternalRegistry   = "registry.ci.openshift.org/integr8ly"
 )

--- a/cmd/openshiftCIRelease_test.go
+++ b/cmd/openshiftCIRelease_test.go
@@ -98,19 +98,19 @@ func Test_updateCIOperatorConfig(t *testing.T) {
 			args: args{
 				repoDir: validReleaseDirTmp,
 				olmType: types.OlmTypeRhmi,
-				version: "2.0.0-rc1",
+				version: "2.20.0-rc1",
 			},
 			verify: func(repoDir string) error {
-				content, err := ioutil.ReadFile(path.Join(repoDir, "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.0.yaml"))
+				content, err := ioutil.ReadFile(path.Join(repoDir, "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.20.yaml"))
 				if err != nil {
 					return err
 				}
-				promotionStr := "promotion:\n  name: \"2.0\""
+				promotionStr := "promotion:\n  name: \"2.20\""
 				if strings.Index(string(content), promotionStr) < 0 {
 					return fmt.Errorf("missing content: %s", promotionStr)
 				}
 
-				branchStr := "zz_generated_metadata:\n  branch: release-v2.0"
+				branchStr := "zz_generated_metadata:\n  branch: release-v2.20"
 				if strings.Index(string(content), branchStr) < 0 {
 					return fmt.Errorf("missing content: %s", branchStr)
 				}
@@ -123,19 +123,19 @@ func Test_updateCIOperatorConfig(t *testing.T) {
 			args: args{
 				repoDir: validReleaseDirTmp,
 				olmType: types.OlmTypeRhoam,
-				version: "1.1.0-rc1",
+				version: "1.20.0-rc1",
 			},
 			verify: func(repoDir string) error {
-				content, err := ioutil.ReadFile(path.Join(repoDir, "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.1.yaml"))
+				content, err := ioutil.ReadFile(path.Join(repoDir, "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.20.yaml"))
 				if err != nil {
 					return err
 				}
-				promotionStr := "promotion:\n  name: \"1.1\""
+				promotionStr := "promotion:\n  name: \"1.20\""
 				if strings.Index(string(content), promotionStr) < 0 {
 					return fmt.Errorf("missing content: %s", promotionStr)
 				}
 
-				branchStr := "zz_generated_metadata:\n  branch: rhoam-release-v1.1"
+				branchStr := "zz_generated_metadata:\n  branch: rhoam-release-v1.20"
 				if strings.Index(string(content), branchStr) < 0 {
 					return fmt.Errorf("missing content: %s", branchStr)
 				}

--- a/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.8.yaml
+++ b/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.8.yaml
@@ -22,13 +22,6 @@ images:
           - destination_dir: .
             source_path: /go/src/github.com/integr8ly/integreatly-operator/build
     to: integreatly-operator
-  - dockerfile_path: Dockerfile.osde2e
-    from: os
-    inputs:
-      openshift_release_golang-1.13:
-        as:
-          - registry.svc.ci.openshift.org/openshift/release:golang-1.13
-    to: integreatly-operator-test-harness-osde2e
   - dockerfile_path: Dockerfile.functional
     from: os
     inputs:
@@ -37,7 +30,7 @@ images:
           - registry.svc.ci.openshift.org/openshift/release:golang-1.13
     to: integreatly-operator-test-harness
 promotion:
-  name: "1.1"
+  name: "2.8"
   namespace: integr8ly
 resources:
   '*':
@@ -49,7 +42,7 @@ resources:
       cpu: 200m
       memory: 2Gi
 tag_specification:
-  name: "4.4"
+  name: "4.3"
   namespace: ocp
 tests:
   - artifact_dir: /tmp/artifacts
@@ -68,12 +61,7 @@ tests:
     container:
       from: src
   - artifact_dir: /tmp/artifacts
-    as: test-cases-lint
-    commands: make test-cases/lint
-    container:
-      from: src
-  - artifact_dir: /tmp/artifacts
-    as: rhoam-e2e
+    as: e2e
     steps:
       cluster_profile: aws
       env:
@@ -81,7 +69,7 @@ tests:
       test:
         - as: test
           cli: latest
-          commands: make test/e2e/rhoam/prow
+          commands: make test/e2e/prow
           from: src
           resources:
             requests:
@@ -92,12 +80,7 @@ tests:
     commands: make manifest/check
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: versions
-    commands: make versions/check
-    container:
-      from: src
 zz_generated_metadata:
-  branch: rhoam-release-v1.1
+  branch: release-v2.8
   org: integr8ly
   repo: integreatly-operator

--- a/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.7.yaml
+++ b/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.7.yaml
@@ -22,6 +22,13 @@ images:
           - destination_dir: .
             source_path: /go/src/github.com/integr8ly/integreatly-operator/build
     to: integreatly-operator
+  - dockerfile_path: Dockerfile.osde2e
+    from: os
+    inputs:
+      openshift_release_golang-1.13:
+        as:
+          - registry.svc.ci.openshift.org/openshift/release:golang-1.13
+    to: integreatly-operator-test-harness-osde2e
   - dockerfile_path: Dockerfile.functional
     from: os
     inputs:
@@ -30,7 +37,7 @@ images:
           - registry.svc.ci.openshift.org/openshift/release:golang-1.13
     to: integreatly-operator-test-harness
 promotion:
-  name: "2.0"
+  name: "1.7"
   namespace: integr8ly
 resources:
   '*':
@@ -42,7 +49,7 @@ resources:
       cpu: 200m
       memory: 2Gi
 tag_specification:
-  name: "4.3"
+  name: "4.4"
   namespace: ocp
 tests:
   - artifact_dir: /tmp/artifacts
@@ -61,7 +68,12 @@ tests:
     container:
       from: src
   - artifact_dir: /tmp/artifacts
-    as: e2e
+    as: test-cases-lint
+    commands: make test-cases/lint
+    container:
+      from: src
+  - artifact_dir: /tmp/artifacts
+    as: rhoam-e2e
     steps:
       cluster_profile: aws
       env:
@@ -69,7 +81,7 @@ tests:
       test:
         - as: test
           cli: latest
-          commands: make test/e2e/prow
+          commands: make test/e2e/rhoam/prow
           from: src
           resources:
             requests:
@@ -80,7 +92,12 @@ tests:
     commands: make manifest/check
     container:
       from: src
+  - artifact_dir: /tmp/artifacts
+    as: versions
+    commands: make versions/check
+    container:
+      from: src
 zz_generated_metadata:
-  branch: release-v2.0
+  branch: rhoam-release-v1.7
   org: integr8ly
   repo: integreatly-operator


### PR DESCRIPTION
Updating the version of the file which is used for generating prow config for new releases.
I've updated the Red Hat Managed Integration one also even though they haven't bumped the go version yet.
We'll likely need to update that one again after the next release if they pull in the go version bump.

cc @MStokluska @pmccarthy 