### PR TITLE
OSD upgrade pipeline changes + refactoring

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -156,7 +156,6 @@ install_addon() {
     completion_phase="${2}"
 
     : "${USE_CLUSTER_STORAGE:=true}"
-    : "${PATCH_CR_AWS_CM:=true}"
     : "${WAIT:=true}"
     : "${QUOTA:=20}"
     cluster_id=$(get_cluster_id)
@@ -196,12 +195,6 @@ install_addon() {
 #   Creating the secrets for RHOAM addons affect how the SLO reporting happens in the nightly RHOAM addon pipelines due to a waiting phase
     if [[ ${addon_id} == "rhmi" ]]; then
         create_secrets
-    fi
-
-    if [[ "${PATCH_CR_AWS_CM}" == true ]]; then
-        echo "Patching Cloud Resources AWS Strategies Config Map"
-        wait_for "oc --kubeconfig ${CLUSTER_KUBECONFIG_FILE} get configMap cloud-resources-aws-strategies -n ${OPERATOR_NAMESPACE} | grep -q cloud-resources-aws-strategies" "cloud-resources-aws-strategies ready" "5m" "20"
-        oc --kubeconfig "${CLUSTER_KUBECONFIG_FILE}" patch configMap cloud-resources-aws-strategies -n "${OPERATOR_NAMESPACE}" --type='json' -p '[{"op": "add", "path": "/data/_network", "value":"{ \"production\": { \"createStrategy\": { \"CidrBlock\": \"'10.1.0.0/23'\" } } }"}]'
     fi
 
     if [[ "${WAIT}" == true ]]; then


### PR DESCRIPTION
### JIRA
https://issues.redhat.com/browse/MGDAPI-196

### Changes
* fixed the OSD upgrade function
* added support for updating (stable) upgrade channel (in case the upgrade requires it)

### To verify (z-stream and y-stream upgrade)
1. Install OSD cluster with version `4.6.27`
2. Get your cluster's credentials:
```bash
OCM_CLUSTER_ID=<your-clusters-id> scripts/ocm/ocm.sh save_cluster_credentials
```
3. Trigger the z-stream upgrade:
```bash
TO_VERSION=latest ./scripts/ocm/ocm.sh upgrade_cluster
```
4. Verify it finished successfully (it could take around 1 hour to finish)
5. Trigger y-stream upgrade:
```bash
TO_VERSION=4.7.19 ./scripts/ocm/ocm.sh upgrade_cluster
```
6. Verify it finished successfully