### PR TITLE
update rhmi release automation

### DIFF
--- a/cmd/openshiftCIAddBranch.go
+++ b/cmd/openshiftCIAddBranch.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	ProwConfigSourceRHMI   = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.8.yaml"
+	ProwConfigSourceRHMI   = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.9.yaml"
 	ProwConfigSourceRHOAM  = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.7.yaml"
 	ProwConfigSourceMaster = "ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-master.yaml"
 	ProwInternalRegistry   = "registry.ci.openshift.org/integr8ly"

--- a/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.9.yaml
+++ b/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-release-v2.9.yaml
@@ -1,18 +1,16 @@
 base_images:
-  openshift_release_golang-1.13:
+  openshift_release_golang-1.16:
     name: release
     namespace: openshift
-    tag: golang-1.13
+    tag: golang-1.16
   os:
     name: ubi
     namespace: ocp
     tag: "8"
 binary_build_commands: make code/compile COMPILE_TARGET="./build/_output/bin/integreatly-operator"
 build_root:
-  image_stream_tag:
-    name: intly-operator-base-image
-    namespace: integr8ly
-    tag: latest
+  project_image:
+    dockerfile_path: openshift-ci/Dockerfile.tools
 images:
   - dockerfile_path: build/Dockerfile
     from: os
@@ -25,12 +23,12 @@ images:
   - dockerfile_path: Dockerfile.functional
     from: os
     inputs:
-      openshift_release_golang-1.13:
+      openshift_release_golang-1.16:
         as:
-          - registry.svc.ci.openshift.org/openshift/release:golang-1.13
+          - registry.svc.ci.openshift.org/openshift/release:golang-1.16
     to: integreatly-operator-test-harness
 promotion:
-  name: "2.8"
+  name: "2.9"
   namespace: integr8ly
 resources:
   '*':
@@ -45,23 +43,19 @@ tag_specification:
   name: "4.3"
   namespace: ocp
 tests:
-  - artifact_dir: /tmp/artifacts
-    as: vendor
+  - as: vendor
     commands: make vendor/check
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: unit
+  - as: unit
     commands: make test/unit
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: format
+  - as: format
     commands: make code/check
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: e2e
+  - as: e2e
     steps:
       cluster_profile: aws
       env:
@@ -75,12 +69,11 @@ tests:
             requests:
               cpu: 100m
       workflow: ipi-aws
-  - artifact_dir: /tmp/artifacts
-    as: manifest
+  - as: manifest
     commands: make manifest/check
     container:
       from: src
 zz_generated_metadata:
-  branch: release-v2.8
+  branch: release-v2.9
   org: integr8ly
   repo: integreatly-operator

--- a/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.7.yaml
+++ b/cmd/testdata/release/ci-operator/config/integr8ly/integreatly-operator/integr8ly-integreatly-operator-rhoam-release-v1.7.yaml
@@ -3,16 +3,18 @@ base_images:
     name: release
     namespace: openshift
     tag: golang-1.13
+  openshift_release_golang-1.16:
+    name: release
+    namespace: openshift
+    tag: golang-1.16
   os:
     name: ubi
     namespace: ocp
     tag: "8"
 binary_build_commands: make code/compile COMPILE_TARGET="./build/_output/bin/integreatly-operator"
 build_root:
-  image_stream_tag:
-    name: intly-operator-base-image
-    namespace: integr8ly
-    tag: latest
+  project_image:
+    dockerfile_path: openshift-ci/Dockerfile.tools
 images:
   - dockerfile_path: build/Dockerfile
     from: os
@@ -25,16 +27,16 @@ images:
   - dockerfile_path: Dockerfile.osde2e
     from: os
     inputs:
-      openshift_release_golang-1.13:
+      openshift_release_golang-1.16:
         as:
-          - registry.svc.ci.openshift.org/openshift/release:golang-1.13
+          - registry.ci.openshift.org/openshift/release:golang-1.16
     to: integreatly-operator-test-harness-osde2e
   - dockerfile_path: Dockerfile.functional
     from: os
     inputs:
-      openshift_release_golang-1.13:
+      openshift_release_golang-1.16:
         as:
-          - registry.svc.ci.openshift.org/openshift/release:golang-1.13
+          - registry.ci.openshift.org/openshift/release:golang-1.16
     to: integreatly-operator-test-harness
 promotion:
   name: "1.7"
@@ -49,31 +51,30 @@ resources:
       cpu: 200m
       memory: 2Gi
 tag_specification:
-  name: "4.4"
+  name: "4.7"
   namespace: ocp
 tests:
-  - artifact_dir: /tmp/artifacts
-    as: vendor
+  - as: vendor
     commands: make vendor/check
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: unit
+  - as: unit
     commands: make test/unit
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: format
+  - as: format
     commands: make code/check
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: test-cases-lint
+  - as: test-cases-lint
     commands: make test-cases/lint
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: rhoam-e2e
+  - as: kubebuilder
+    commands: make kubebuilder/check
+    container:
+      from: src
+  - as: rhoam-e2e
     steps:
       cluster_profile: aws
       env:
@@ -87,13 +88,11 @@ tests:
             requests:
               cpu: 100m
       workflow: ipi-aws
-  - artifact_dir: /tmp/artifacts
-    as: manifest
+  - as: manifest
     commands: make manifest/check
     container:
       from: src
-  - artifact_dir: /tmp/artifacts
-    as: versions
+  - as: versions
     commands: make versions/check
     container:
       from: src


### PR DESCRIPTION
Update the file location of the copied version of Red Hat Managed Integration to 2.8 as the version of go has changed.