### PR TITLE
fix: polarionImport: ignore archives without junit

### DIFF
--- a/cmd/polarionImport.go
+++ b/cmd/polarionImport.go
@@ -180,8 +180,9 @@ func (c *polarionImportCmd) processReportFile(ctx context.Context, object *s3.Ob
 	// upload it to Polarion
 	fmt.Println(fmt.Sprintf("[%s] uploading results to Polarion", *object.Key))
 	err = c.importToPolarion(*object.Key, m, downloaded)
-	// If JUnit
+
 	if err != nil {
+		// If JUnit file is not found, ignore the error and mark the archive as processed
 		if err == errJunitNotFound {
 			fmt.Printf("[%s] %s", *object.Key, errJunitNotFound)
 		} else {


### PR DESCRIPTION
### What

If Jenkins pipeline doesn't manage to create JUnit file (can be caused by a failure when fetching test results, issue with Jenkins slave etc.), it will be now ignored and the archive with test results is marked as processed.