### PR TITLE
OCM script - check for existing cluster

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -83,7 +83,7 @@ create_cluster_configuration_file() {
     jq ".expiration_timestamp = \"${timestamp}\" | .name = \"${OCM_CLUSTER_NAME}\" | .display_name = \"${cluster_display_name}\" | .region.id = \"${OCM_CLUSTER_REGION}\" | .api.listening = \"${listening}\"" \
         < "${CLUSTER_TEMPLATE_FILE}" \
         > "${CLUSTER_CONFIGURATION_FILE}"
-	
+
     if [ "${BYOC}" = true ]; then
         check_aws_credentials_exported
         update_configuration "aws"
@@ -105,7 +105,7 @@ create_cluster_configuration_file() {
         update_configuration "compute_machine_type"
     fi
 
-    
+
 
 
     cat "${CLUSTER_CONFIGURATION_FILE}"
@@ -161,7 +161,7 @@ install_addon() {
     cluster_id=$(get_cluster_id)
     addon_payload="{\"addon\":{\"id\":\"${addon_id}\"}}"
 
-    # Add mandatory "cidr-range" and "addon-managed-api-service" (quota) params with default value in case of rhoam (managed-api-service) addon 
+    # Add mandatory "cidr-range" and "addon-managed-api-service" (quota) params with default value in case of rhoam (managed-api-service) addon
     if [[ "${addon_id}" == "managed-api-service" ]]; then
     	addon_payload="{\"addon\":{\"id\":\"${addon_id}\"}, \"parameters\": { \"items\": [{\"id\": \"cidr-range\", \"value\": \"10.1.0.0/26\"}, {\"id\": \"addon-resource-required\", \"value\": \"true\" }, {\"id\": \"addon-managed-api-service\", \"value\": \"${QUOTA}\"}] }}"
     fi
@@ -256,7 +256,7 @@ upgrade_cluster() {
     fi
 
     upgradesAvailable=$(ocm get cluster "${cluster_id}" | jq -r '.version.available_upgrades | values')
-    
+
     if [[ $upgradesAvailable != "" ]]; then
         channel_version=$(get_channel_version)
         echo "Current version of cluster's upgrade channel is ${channel_version}"
@@ -320,7 +320,14 @@ get_infra_id() {
 
 send_cluster_create_request() {
     local cluster_details
-    cluster_details=$(ocm post /api/clusters_mgmt/v1/clusters --body="${CLUSTER_CONFIGURATION_FILE}" | jq -r | tee "${CLUSTER_DETAILS_FILE}")
+    ocm_command="ocm post /api/clusters_mgmt/v1/clusters --body='${CLUSTER_CONFIGURATION_FILE}'"
+    # Get existing cluster details if exists to avoid DuplicateClusterName error
+    existing_cluster_id=$(ocm get /api/clusters_mgmt/v1/clusters | jq -r ".items[] | select(.name==\"${OCM_CLUSTER_NAME}\") | .id")
+    if [[ ! -z "${existing_cluster_id:-}" ]]; then
+        ocm_command="ocm get /api/clusters_mgmt/v1/clusters/${existing_cluster_id}"
+    fi
+
+    cluster_details=$(eval ${ocm_command} | jq -r | tee "${CLUSTER_DETAILS_FILE}")
     if [[ -z "${cluster_details:-}" ]]; then
         printf "Something went wrong with cluster create request\n"
         exit 1

--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -309,6 +309,10 @@ get_cluster_region() {
     jq -r .region.id < "${CLUSTER_DETAILS_FILE}"
 }
 
+get_existing_cluster_id() {
+    ocm get clusters --parameter search="name like '$(get_cluster_name)'" | jq -r '.items[0].id'
+}
+
 is_ccs_cluster() {
     jq -r .ccs.enabled < "${CLUSTER_DETAILS_FILE}"
 }
@@ -329,7 +333,7 @@ send_cluster_create_request() {
 
     ocm_command="ocm post /api/clusters_mgmt/v1/clusters --body='${CLUSTER_CONFIGURATION_FILE}'"
     # Get existing cluster details if exists to avoid DuplicateClusterName error
-    existing_cluster_id=$(ocm get /api/clusters_mgmt/v1/clusters | jq -r ".items[] | select(.name==\"$(get_cluster_name)\") | .id")
+    existing_cluster_id=$(get_existing_cluster_id)
     if [[ ! -z "${existing_cluster_id:-}" ]]; then
         ocm_command="ocm get /api/clusters_mgmt/v1/clusters/${existing_cluster_id}"
         echo "Info: Cluster with the given name already exists, continue with the existing cluster details"

--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -310,7 +310,7 @@ get_cluster_region() {
 }
 
 get_existing_cluster_id() {
-    ocm get clusters --parameter search="name like '$(get_cluster_name)'" | jq -r '.items[0].id'
+    ocm get clusters --parameter search="name like '$(get_cluster_name)'" | jq -r '.items[0].id // empty'
 }
 
 is_ccs_cluster() {

--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -297,6 +297,10 @@ get_cluster_id() {
     jq -r .id < "${CLUSTER_DETAILS_FILE}"
 }
 
+get_cluster_name() {
+    jq -r .name < "${CLUSTER_CONFIGURATION_FILE}"
+}
+
 get_cluster_subscription_id() {
     jq -r .subscription.id < "${CLUSTER_DETAILS_FILE}"
 }
@@ -320,13 +324,16 @@ get_infra_id() {
 
 send_cluster_create_request() {
     local cluster_details
+    local existing_cluster_id
+    local ocm_command
+
     ocm_command="ocm post /api/clusters_mgmt/v1/clusters --body='${CLUSTER_CONFIGURATION_FILE}'"
     # Get existing cluster details if exists to avoid DuplicateClusterName error
-    existing_cluster_id=$(ocm get /api/clusters_mgmt/v1/clusters | jq -r ".items[] | select(.name==\"${OCM_CLUSTER_NAME}\") | .id")
+    existing_cluster_id=$(ocm get /api/clusters_mgmt/v1/clusters | jq -r ".items[] | select(.name==\"$(get_cluster_name)\") | .id")
     if [[ ! -z "${existing_cluster_id:-}" ]]; then
         ocm_command="ocm get /api/clusters_mgmt/v1/clusters/${existing_cluster_id}"
+        echo "Info: Cluster with the given name already exists, continue with the existing cluster details"
     fi
-
     cluster_details=$(eval ${ocm_command} | jq -r | tee "${CLUSTER_DETAILS_FILE}")
     if [[ -z "${cluster_details:-}" ]]; then
         printf "Something went wrong with cluster create request\n"

--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -334,11 +334,11 @@ send_cluster_create_request() {
     ocm_command="ocm post /api/clusters_mgmt/v1/clusters --body='${CLUSTER_CONFIGURATION_FILE}'"
     # Get existing cluster details if exists to avoid DuplicateClusterName error
     existing_cluster_id=$(get_existing_cluster_id)
-    if [[ ! -z "${existing_cluster_id:-}" ]]; then
+    if [[ -n "${existing_cluster_id:-}" ]]; then
         ocm_command="ocm get /api/clusters_mgmt/v1/clusters/${existing_cluster_id}"
         echo "Info: Cluster with the given name already exists, continue with the existing cluster details"
     fi
-    cluster_details=$(eval ${ocm_command} | jq -r | tee "${CLUSTER_DETAILS_FILE}")
+    cluster_details=$(eval "${ocm_command}" | jq -r | tee "${CLUSTER_DETAILS_FILE}")
     if [[ -z "${cluster_details:-}" ]]; then
         printf "Something went wrong with cluster create request\n"
         exit 1


### PR DESCRIPTION
**Description**
Add a check if there a cluster already exists with the specified cluster name, if it exists get existing cluster details and proceed further, otherwise, send a request to create a new cluster. I wasn't sure if it's a breaking change, pls could you advise and I can add an extra variable which can indicate if the existing cluster should be used or ignored as it was before. Thank you!

**Use Case**
As a User I would like to use this script in a Jenkins parallel job so when several jobs execute the create_cluster method with the same cluster name they would use the same cluster. In this case I don't need to wait for the first job to finish before triggering other jobs. 

**Testing**
1. Tried to execute new cluster creation using unique cluster name - new cluster was created.
2. Tried to create a new cluster using the same name from step 1 - it picked up existing cluster details and proceeded to wait for its ready status.