### PR TITLE
Added an option to deploy an OSD trial cluster

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -64,6 +64,7 @@ create_cluster_configuration_file() {
     : "${MULTI_AZ:=false}"
     : "${COMPUTE_NODES_COUNT:=}"
     : "${COMPUTE_MACHINE_TYPE:=}"
+    : "${OSD_TRIAL:=false}"
 
     timestamp=$(get_expiration_timestamp "${OCM_CLUSTER_LIFESPAN}")
 
@@ -104,7 +105,9 @@ create_cluster_configuration_file() {
     if [[ -n "${COMPUTE_MACHINE_TYPE}" ]]; then
         update_configuration "compute_machine_type"
     fi
-
+    if [[ "${OSD_TRIAL}" = true ]]; then
+        update_configuration "osd_trial"
+    fi
 
 
 
@@ -406,6 +409,9 @@ update_configuration() {
 
     compute_machine_type)
         updated_configuration=$(jq ".nodes.compute_machine_type.id = \"${COMPUTE_MACHINE_TYPE}\"" < "${CLUSTER_CONFIGURATION_FILE}")
+        ;;
+    osd_trial)
+        updated_configuration=$(jq '.product.id = "osdtrial"' < "${CLUSTER_CONFIGURATION_FILE}")
         ;;
 
     *)

--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -460,6 +460,7 @@ Optional exported variables:
 - MULTI_AZ                          true/false (default: false)
 - COMPUTE_NODES_COUNT               number of cluster's compute nodes (default: 8 in cluster-template. Can be specified otherwise)
 - COMPUTE_MACHINE_TYPE              node type of cluster's compute nodes (default: m5.xlarge, can be specified otherwise)
+- OSD_TRIAL                         true/false (default: false)
 ==========================================================================================================
 create_cluster                    - spin up OSD cluster
 ----------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
tested with
`make OCM_CLUSTER_LIFESPAN=4 OCM_CLUSTER_NAME=mhesko-osdtrial OCM_CLUSTER_REGION=us-west-1 MULTI_AZ=false COMPUTE_NODES_COUNT=6 COMPUTE_MACHINE_TYPE=m5.xlarge OSD_TRIAL=true ocm/cluster.json`
`make ocm/cluster/create`
and everything deployed correctly, need this merged to implement OSD trial functionality into our pipelines