### PR TITLE
Fix openshift-ci-release - skip on patch releases

### DIFF
--- a/cmd/openshiftCIRelease.go
+++ b/cmd/openshiftCIRelease.go
@@ -4,12 +4,13 @@ import (
 	"bufio"
 	"context"
 	"fmt"
-	"github.com/integr8ly/delorean/pkg/types"
 	"os"
 	"os/exec"
 	"path"
 	"strings"
 	"time"
+
+	"github.com/integr8ly/delorean/pkg/types"
 
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/config"
@@ -369,7 +370,7 @@ func init() {
 			if err != nil {
 				handleError(err)
 			}
-			if c.version.IsPreRelease() {
+			if c.version.IsPatchRelease() {
 				fmt.Println("Skipping the update to Openshift CI release repo as the release version is not a major or a minor one")
 				return
 			}


### PR DESCRIPTION
The `delorean release openshift-ci-release` command was intended to be skipped when running with a patch release, but the condition calls incorrect function.