### PR TITLE
Use local PATH in create release

### DIFF
--- a/cmd/createRelease.go
+++ b/cmd/createRelease.go
@@ -152,6 +152,8 @@ func (c *createReleaseCmd) runReleaseScript(repoDir string) error {
 	} else {
 		envs = append(envs, "SERVICE_AFFECTING=false")
 	}
+	// pass your local PATH config to the script in case opeartor-sdk or other prereq binary is in unusal location
+	envs = append(envs, "PATH="+os.Getenv("PATH"))
 	releaseScript := &exec.Cmd{Dir: repoDir, Env: envs, Path: c.releaseScript, Stdout: os.Stdout, Stderr: os.Stderr}
 	return releaseScript.Run()
 }


### PR DESCRIPTION
This helps with local dev/test.
Locally I was getting following error:
```
scripts/prepare-release.sh: line 52: operator-sdk: command not found
```
It's fixed with this change.