### PR TITLE
added a way to install RHOAM on OSD trial cluster using addon-flow

### DIFF
--- a/make/ocm.mk
+++ b/make/ocm.mk
@@ -44,6 +44,10 @@ ocm/install/rhmi-addon:
 ocm/install/rhoam-addon:
 	@${OCM_SH} install_rhoam
 
+.PHONY: ocm/install/rhoam-addon-trial
+ocm/install/rhoam-addon-trial:
+	@${OCM_SH} install_rhoam_trial
+
 .PHONY: ocm/cluster/delete
 ocm/cluster/delete:
 	@${OCM_SH} delete_cluster


### PR DESCRIPTION
had to add a new function to differentiate between an install on regular and trial cluster, for some reason they use different parameter names for their quota.

Tested out successfully on my local jenkinks