### PR TITLE
fix: ocm: typo

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -326,7 +326,7 @@ get_cluster_region() {
 }
 
 get_existing_cluster_id() {
-    ocm get clusters --parameter search="name like '$(get_cluster_name)'" | jq -r '.items[0].id // empty'
+    ocm get clusters --parameter search="name like '$(get_cluster_name)'" | jq -r '.items[0].id | values'
 }
 
 is_ccs_cluster() {


### PR DESCRIPTION
Hi @echernous, I just noticed an error when I tried to create a cluster with cluster id that was already there. Not sure how I missed it in the original PR verification :)

I assume that "[`// empty`](https://github.com/integr8ly/delorean/compare/master...psturc:ocm-fix-typo?expand=1#diff-b26057c72b176f72b860716e58baec8c2a636cfd8c12b40bc199ff6c16653892L329)" was a typo/put there by accident?