### PR TITLE
MGDAPI-2561: Adapt CSV processing for multiple containers

### DIFF
--- a/cmd/processCSVImages_test.go
+++ b/cmd/processCSVImages_test.go
@@ -3,12 +3,13 @@ package cmd
 import (
 	"bufio"
 	"context"
-	"github.com/integr8ly/delorean/pkg/utils"
 	"io/ioutil"
 	"os"
 	"path"
 	"regexp"
 	"testing"
+
+	"github.com/integr8ly/delorean/pkg/utils"
 )
 
 func mockProcessCSVImages(manifestDir string, isGa bool, extraImages string) error {
@@ -138,6 +139,7 @@ func TestProcessCSVImages(t *testing.T) {
 					"registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-memcached-rhel7@sha256:ff5f3d2d131631d5db8985a5855ff4607e91f0aa86d07dafdcec4f7da13c9e05 quay.io/integreatly/delorean:3scale-amp2-memcached-rhel7_ff5f3d2d131631d5db8985a5855ff4607e91f0aa86d07dafdcec4f7da13c9e05",
 					"registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-system-rhel7@sha256:93819c324831353bb8f7cb6e9910694b88609c3a20d4c1b9a22d9c2bbfbad16f quay.io/integreatly/delorean:3scale-amp2-system-rhel7_93819c324831353bb8f7cb6e9910694b88609c3a20d4c1b9a22d9c2bbfbad16f",
 					"registry-proxy.engineering.redhat.com/rh-osbs/3scale-amp2-zync-rhel7@sha256:f4d5c1fdebe306f4e891ddfc4d3045a622d2f01db21ecfc9397cab25c9baa91a quay.io/integreatly/delorean:3scale-amp2-zync-rhel7_f4d5c1fdebe306f4e891ddfc4d3045a622d2f01db21ecfc9397cab25c9baa91a",
+					"registry-proxy.engineering.redhat.com/rh-osbs/openshift4-ose-kube-rbac-proxy@sha256:484e26e348354e6dd28934aedbcd139c786284a88a4e16a7652b5a52bd0beeac quay.io/integreatly/delorean:openshift4-ose-kube-rbac-proxy_484e26e348354e6dd28934aedbcd139c786284a88a4e16a7652b5a52bd0beeac",
 					"registry-proxy.engineering.redhat.com/rh-osbs/rhscl-mysql-57-rhel7@sha256:9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe quay.io/integreatly/delorean:rhscl-mysql-57-rhel7_9a781abe7581cc141e14a7e404ec34125b3e89c008b14f4e7b41e094fd3049fe",
 					"registry-proxy.engineering.redhat.com/rh-osbs/rhscl-postgresql-10-rhel7@sha256:de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd quay.io/integreatly/delorean:rhscl-postgresql-10-rhel7_de3ab628b403dc5eed986a7f392c34687bddafee7bdfccfd65cecf137ade3dfd",
 					"registry-proxy.engineering.redhat.com/rh-osbs/rhscl-redis-32-rhel7@sha256:a9bdf52384a222635efc0284db47d12fbde8c3d0fcb66517ba8eefad1d4e9dc9 quay.io/integreatly/delorean:rhscl-redis-32-rhel7_a9bdf52384a222635efc0284db47d12fbde8c3d0fcb66517ba8eefad1d4e9dc9",

--- a/pkg/utils/testdata/validManifests/3scale/0.4.0/3scale-operator.v0.4.0.clusterserviceversion.yaml
+++ b/pkg/utils/testdata/validManifests/3scale/0.4.0/3scale-operator.v0.4.0.clusterserviceversion.yaml
@@ -142,6 +142,17 @@ spec:
                 name: threescale-operator
             spec:
               containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:484e26e348354e6dd28934aedbcd139c786284a88a4e16a7652b5a52bd0beeac
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources: {}
               - command:
                 - 3scale-operator
                 env:

--- a/pkg/utils/testdata/validManifests/3scale2/0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml
+++ b/pkg/utils/testdata/validManifests/3scale2/0.5.0/3scale-operator.v0.5.0.clusterserviceversion.yaml
@@ -154,6 +154,17 @@ spec:
                 name: threescale-operator
             spec:
               containers:
+              - args:
+                - --secure-listen-address=0.0.0.0:8443
+                - --upstream=http://127.0.0.1:8080/
+                - --logtostderr=true
+                - --v=10
+                image: registry.redhat.io/openshift4/ose-kube-rbac-proxy@sha256:484e26e348354e6dd28934aedbcd139c786284a88a4e16a7652b5a52bd0beeac
+                name: kube-rbac-proxy
+                ports:
+                - containerPort: 8443
+                  name: https
+                resources: {}
               - command:
                 - 3scale-operator
                 env:


### PR DESCRIPTION
The `ews process-csv` command processes the CSV to generate an image mirror mapping file. In order to do this it finds image references in relevant fields, including the containers field of the operator Deployment. In the past, operators would have only one container (the controller manager itself), but newer operators, since the release of operator-sdk 1.0, include a proxy container.

The CSV processing logic would take only the first container for
processing, thi change iterates through the containers list and
processes them all.

Adapt the unit tests to consider this situation