### PR TITLE
Update prometheus namespace and route in downtime report

### DIFF
--- a/cmd/queryReport.go
+++ b/cmd/queryReport.go
@@ -30,8 +30,8 @@ import (
 type queryType string
 
 const (
-	prometheusNamespace           = "redhat-rhmi-middleware-monitoring-operator"
-	prometheusRouteName           = "prometheus-route"
+	prometheusNamespace           = "redhat-rhoam-observability"
+	prometheusRouteName           = "prometheus"
 	promQueryType       queryType = "query"
 	promQueryRangeType  queryType = "query_range"
 	defaultWorkers                = 5

--- a/cmd/queryReport_test.go
+++ b/cmd/queryReport_test.go
@@ -43,7 +43,6 @@ func TestQueryReportCmd(t *testing.T) {
 		t.Fatalf("Failed to create output dir: %v", err)
 	}
 	defer os.RemoveAll(outputDir)
-	namespace := "test"
 	queries := []queryOpts{
 		{
 			QueryType: promQueryType,
@@ -135,7 +134,6 @@ func TestQueryReportCmd(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.description, func(t *testing.T) {
 			cmd := &queryReportCmd{
-				namespace: namespace,
 				outputDir: outputDir,
 				promAPI:   c.promAPI,
 				config:    c.config,


### PR DESCRIPTION
Fixes the downtime report for RHOAM v1.13+.
The potential issue is that this would not work with RHOAM v1.12 and older releases. And it won't work with RHMI either. The `prometheusNamespace` can be specified via command line as input parameter but the `prometheusRouteName` cannot.

So it might be better to update this to work with RHMI/RHOAM v1.12- too, but given the low probability of needing that and simplicity of local workaround it might not be worth doing that.

**Verification Steps**

Just run the report against some RHOAM cluster:
```
make build/cli
./delorean pipeline query-report --namespace redhat-rhoam-observability --config-file ./configurations/downtime-report-config-rhoam.yaml -o <output_dir>
```