### PR TITLE
Added a way to pass arguments to the remote container

### DIFF
--- a/cmd/productTests.go
+++ b/cmd/productTests.go
@@ -37,7 +37,7 @@ type TestContainer struct {
 	ImagePullSecret string      `json:"ImagePullSecretEnvVar,omitempty"`
 	EnvVars         []v1.EnvVar `json:"envVars,omitempty"`
 	RegExpFilter    string      `json:"regExpFilter,omitempty`
-    Argument        string      `json:"argument, omitempty`
+	Argument        string      `json:"argument, omitempty`
 	Success         bool
 }
 
@@ -329,7 +329,7 @@ func parseSecretName(pullSecret string) string {
 }
 func assignArguments(t *TestContainer) []string {
 	if t.Argument != "" {
-        return []string{t.Argument}
-    }
-    return []string{"-ginkgo.focus", t.RegExpFilter}
+		return []string{t.Argument}
+	}
+	return []string{"-ginkgo.focus", t.RegExpFilter}
 }

--- a/cmd/productTests.go
+++ b/cmd/productTests.go
@@ -37,6 +37,7 @@ type TestContainer struct {
 	ImagePullSecret string      `json:"ImagePullSecretEnvVar,omitempty"`
 	EnvVars         []v1.EnvVar `json:"envVars,omitempty"`
 	RegExpFilter    string      `json:"regExpFilter,omitempty`
+    Argument        string      `json:"argument, omitempty`
 	Success         bool
 }
 
@@ -263,7 +264,7 @@ func getTestContainerJob(namespace string, t *TestContainer) *batchv1.Job {
 							},
 							Env: t.EnvVars,
 							//Command: []string{"/integreatly-operator-test-harness.test"},
-							Args: []string{"-ginkgo.focus", t.RegExpFilter},
+							Args: assignArguments(t),
 						},
 						{
 							Name:  "sidecar",
@@ -325,4 +326,10 @@ func (c *runTestsCmd) completeJob(pod v1.Pod) error {
 
 func parseSecretName(pullSecret string) string {
 	return strings.ToLower(strings.ReplaceAll(pullSecret, "_", "-"))
+}
+func assignArguments(t *TestContainer) []string {
+	if t.Argument != "" {
+        return []string{t.Argument}
+    }
+    return []string{"-ginkgo.focus", t.RegExpFilter}
 }


### PR DESCRIPTION
This PR is related to the main PR that can be found[here](https://gitlab.cee.redhat.com/integreatly-qe/ci-cd/-/merge_requests/593)

This way all we need to run a different set of tests in the 3scale test suite is to change a line in the .yaml configuration file