### PR TITLE
fix: aws cleanup: ignore terminated ec2 instances

### DIFF
--- a/cmd/cleanupAwsAccount.go
+++ b/cmd/cleanupAwsAccount.go
@@ -268,6 +268,9 @@ func (c *cleanupAwsAccountCmd) fetchEC2Instances(ctx context.Context) error {
 
 	for _, reservation := range fetchedReservations.Reservations {
 		for _, ec2Instance := range reservation.Instances {
+			if aws.StringValue(ec2Instance.State.Name) == "terminated" {
+				continue
+			}
 			newEc2 := awsResourceObject{
 				ID:           aws.StringValue(ec2Instance.InstanceId),
 				resourceType: "ec2Instance",

--- a/cmd/cleanupAwsAccount_test.go
+++ b/cmd/cleanupAwsAccount_test.go
@@ -49,6 +49,7 @@ func TestCleanupAwsCmd(t *testing.T) {
 									Tags: []*ec2.Tag{
 										{Key: aws.String("kubernetes.io/cluster/dont-delete-me"), Value: aws.String("owned")},
 									},
+									State: &ec2.InstanceState{Name: aws.String("running")},
 								},
 							},
 						},
@@ -149,7 +150,15 @@ func TestCleanupAwsCmd(t *testing.T) {
 				DescribeInstancesOutput: &ec2.DescribeInstancesOutput{
 					Reservations: []*ec2.Reservation{
 						{
-							Instances: []*ec2.Instance{},
+							Instances: []*ec2.Instance{
+								{
+									InstanceId: aws.String("Terminated OSD instance"),
+									Tags: []*ec2.Tag{
+										{Key: aws.String("kubernetes.io/cluster/delete-me"), Value: aws.String("owned")},
+									},
+									State: &ec2.InstanceState{Name: aws.String("terminated")},
+								},
+							},
 						},
 					},
 				},


### PR DESCRIPTION
### Description

If the cleanup command runs while related OSD cluster's EC2 instances are still present in AWS (but in `terminated` state), they are still counted as resources that should block the deletion of RHOAM AWS resources (which is incorrect).

These terminated EC2 instances are removed by AWS after a while, so the cleanup command would do the work correctly after they're gone (usually after couple of hours).

This PR contains a fix which allows deleting RHOAM AWS resources immediately right after all OSD cluster EC2 instances are terminated.

### Verification

Verified against the cluster that was freshly terminated while related RHOAM resources were still present in AWS