### PR TITLE
Update the root image golang-1.16

### DIFF
--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/openshift/release:golang-1.13
+FROM registry.ci.openshift.org/openshift/release:golang-1.16
 
 ENV SHELLCHECK_VERSION=v0.7.0
 

--- a/openshift-ci/README.md
+++ b/openshift-ci/README.md
@@ -8,6 +8,7 @@ Base image used on CI for all builds and test jobs. See [here](https://github.co
 
 ```
 $ docker build -t registry.svc.ci.openshift.org/integr8ly/delorean-base-image:latest - < Dockerfile.tools
+$ chmod +x test/run
 $ IMAGE_NAME=registry.svc.ci.openshift.org/integr8ly/delorean-base-image:latest test/run
 ShellCheck - shell script analysis tool
 version: 0.7.0


### PR DESCRIPTION
JIRA Link: https://issues.redhat.com/browse/MGDAPI-2465

This change updates the root image to point to the correct location and also updates the version of Go that Prow uses to 1.16. This is required for MGDAPI-2465 because it requires Go version 1.16 to implement the `extract-bundle` and `process-bundle commands`.

I will submit a new PR for MGDAPI-2465 that will include bumping the version of Go for delorean itself but I can't submit that PR because it will fail the prow tests until Prow's version of Go is updated first.