### PR TITLE
MGDAPI-3430 Updated code to reset node count to 5

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -27,6 +27,8 @@ readonly ERROR_MISSING_CLUSTER_ID="ERROR: OCM_CLUSTER_ID was not specified"
 
 readonly WARNING_CLUSTER_HEALTH_CHECK_FAILED="WARNING: Cluster was not reported as healthy. You might expect some issues while working with the cluster."
 
+LOCAL_RUN=${LOCAL_RUN:-true}
+
 check_aws_credentials_exported() {
     if [[ -z "${AWS_ACCOUNT_ID:-}" || -z "${AWS_SECRET_ACCESS_KEY:-}" || -z "${AWS_ACCESS_KEY_ID:-}" ]]; then
         printf "%s\n" "${ERROR_MISSING_AWS_ENV_VARS}"
@@ -324,6 +326,10 @@ get_cluster_name() {
     jq -r .name < "${CLUSTER_CONFIGURATION_FILE}"
 }
 
+get_cluster_node_count() {
+    jq -r .nodes.compute < "${CLUSTER_CONFIGURATION_FILE}"
+}
+
 get_cluster_subscription_id() {
     jq -r .subscription.id < "${CLUSTER_DETAILS_FILE}"
 }
@@ -354,6 +360,27 @@ send_cluster_create_request() {
     local existing_cluster_id
     local ocm_command
 
+    LOOP=${LOOP:-true}
+    tmp=$(mktemp)
+    NODE_AMOUNT=$(get_cluster_node_count)
+    if [ "$LOCAL_RUN" = true ]; then 
+       while [ "$LOOP" = true ]; 
+       do 
+       read -p "Are you sure you need a ${NODE_AMOUNT} node cluster (Y/N)? Please consider a smaller cluster if it will satisfy your development needs." -n 1 -r 
+       if [[ $REPLY =~ ^[Yy]$ ]]; then 
+          jq '.nodes.compute = '"${NODE_AMOUNT}"'' "${CLUSTER_CONFIGURATION_FILE}" > "$tmp" && mv "$tmp" "${CLUSTER_CONFIGURATION_FILE}"
+          echo $'\nCluster with '"${NODE_AMOUNT}"' nodes will be created.' 
+          LOOP=false 
+       elif [[ "$REPLY" =~ ^[Nn]$ ]]; then 
+          echo "" 
+          read -p "How many nodes would you like? " -n 1 -r 
+          echo $'\nCluster with '"$REPLY"' nodes will be created.' 
+          jq '.nodes.compute = '"${REPLY}"'' "${CLUSTER_CONFIGURATION_FILE}" > "$tmp" && mv "$tmp" "${CLUSTER_CONFIGURATION_FILE}" 
+          LOOP=false 
+        else echo $'\nPlease input either "Y" or "N"' 
+       fi 
+       done 
+    fi
     ocm_command="ocm post /api/clusters_mgmt/v1/clusters --body='${CLUSTER_CONFIGURATION_FILE}'"
     # Get existing cluster details if exists to avoid DuplicateClusterName error
     existing_cluster_id=$(get_existing_cluster_id)
@@ -486,7 +513,7 @@ Optional exported variables:
 - OPENSHIFT_VERSION                 to get OpenShift versions, run: ocm cluster versions
 - PRIVATE                           Cluster's API and router will be private
 - MULTI_AZ                          true/false (default: false)
-- COMPUTE_NODES_COUNT               number of cluster's compute nodes (default: 8 in cluster-template. Can be specified otherwise)
+- COMPUTE_NODES_COUNT               number of cluster's compute nodes (default: 5 in cluster-template. Can be specified otherwise)
 - COMPUTE_MACHINE_TYPE              node type of cluster's compute nodes (default: m5.xlarge, can be specified otherwise)
 - OSD_TRIAL                         true/false (default: false)
 ==========================================================================================================

--- a/templates/ocm/cluster-template.json
+++ b/templates/ocm/cluster-template.json
@@ -1,23 +1,24 @@
 {
-    "display_name": "long_cluster_name",
-    "ccs": {
-      "enabled": false
-    },
-    "managed": true,
-    "multi_az": false,
-    "name": "my_cluster_name",
-    "network": {
-      "machine_cidr": "10.11.128.0/23",
-      "service_cidr": "10.11.0.0/18",
-      "pod_cidr": "10.11.64.0/18",
-      "host_prefix": 23
-    },
-    "nodes" : {
-      "compute" : 8,
-      "compute_machine_type" : {"id" : "m5.xlarge" }
-    },
-    "region": {
-      "id": "eu-west-1"
+  "display_name": "long_cluster_name",
+  "ccs": {
+    "enabled": false
+  },
+  "managed": true,
+  "multi_az": false,
+  "name": "my_cluster_name",
+  "network": {
+    "machine_cidr": "10.11.128.0/23",
+    "service_cidr": "10.11.0.0/18",
+    "pod_cidr": "10.11.64.0/18",
+    "host_prefix": 23
+  },
+  "nodes": {
+    "compute": 5,
+    "compute_machine_type": {
+      "id": "m5.xlarge"
     }
+  },
+  "region": {
+    "id": "eu-west-1"
+  }
 }
-  


### PR DESCRIPTION
Previously when the user chose "Nn" and set the node count to a number other than 5, then tried to make a new cluster and chose "Yy" the amount of nodes would remain and not be set to the default. This pr fixes that.
Extension of https://issues.redhat.com/browse/MGDAPI-3430