### PR TITLE
updated the products test module to accept different entrypoints

### DIFF
--- a/cmd/productTests.go
+++ b/cmd/productTests.go
@@ -36,8 +36,9 @@ type TestContainer struct {
 	Timeout         int64       `json:"timeout,omitempty"`
 	ImagePullSecret string      `json:"ImagePullSecretEnvVar,omitempty"`
 	EnvVars         []v1.EnvVar `json:"envVars,omitempty"`
-	RegExpFilter    string      `json:"regExpFilter,omitempty`
-	Argument        string      `json:"argument, omitempty`
+	RegExpFilter    string      `json:"regExpFilter,omitempty"`
+	Entrypoint      []string    `json:"entrypoint, omitempty"`
+	Argument        []string    `json:"argument, omitempty"`
 	Success         bool
 }
 
@@ -263,7 +264,7 @@ func getTestContainerJob(namespace string, t *TestContainer) *batchv1.Job {
 								},
 							},
 							Env:     t.EnvVars,
-							Command: assignEntrypoint(t),
+							Command: t.Entrypoint,
 							Args:    assignArguments(t),
 						},
 						{
@@ -328,16 +329,9 @@ func parseSecretName(pullSecret string) string {
 	return strings.ToLower(strings.ReplaceAll(pullSecret, "_", "-"))
 }
 
-func assignEntrypoint(t *TestContainer) []string {
-	if t.Argument != "" {
-		return []string{"sh"}
-	}
-	return []string{"/integreatly-operator-test-harness.test"}
-}
-
 func assignArguments(t *TestContainer) []string {
-	if t.Argument != "" {
-		return []string{"-c", fmt.Sprintf("oc project redhat-rhoam-3scale; make %s", t.Argument)}
+	if len(t.Argument) > 0 {
+		return t.Argument
 	}
 	return []string{"-ginkgo.focus", t.RegExpFilter}
 }

--- a/cmd/productTests.go
+++ b/cmd/productTests.go
@@ -263,7 +263,7 @@ func getTestContainerJob(namespace string, t *TestContainer) *batchv1.Job {
 								},
 							},
 							Env: t.EnvVars,
-							//Command: []string{"/integreatly-operator-test-harness.test"},
+							Command: assignEntrypoint(t),
 							Args: assignArguments(t),
 						},
 						{
@@ -327,9 +327,17 @@ func (c *runTestsCmd) completeJob(pod v1.Pod) error {
 func parseSecretName(pullSecret string) string {
 	return strings.ToLower(strings.ReplaceAll(pullSecret, "_", "-"))
 }
+
+func assignEntrypoint(t *TestContainer) []string {
+	if t.Argument != "" {
+		return []string{"sh"}
+	}
+	return []string{"/integreatly-operator-test-harness.test"}
+}
+
 func assignArguments(t *TestContainer) []string {
 	if t.Argument != "" {
-		return []string{t.Argument}
+		return []string{"-c", fmt.Sprintf("oc project redhat-rhoam-3scale; make %s", t.Argument)}
 	}
 	return []string{"-ginkgo.focus", t.RegExpFilter}
 }

--- a/cmd/productTests.go
+++ b/cmd/productTests.go
@@ -262,9 +262,9 @@ func getTestContainerJob(namespace string, t *TestContainer) *batchv1.Job {
 									MountPath: "/test-run-results",
 								},
 							},
-							Env: t.EnvVars,
+							Env:     t.EnvVars,
 							Command: assignEntrypoint(t),
-							Args: assignArguments(t),
+							Args:    assignArguments(t),
 						},
 						{
 							Name:  "sidecar",


### PR DESCRIPTION
I added this as a quick fix to have the `sh` entrypoint provided to me when running the 3scale products tests, this approach can be revisited later in [MGDAPI-3086](https://issues.redhat.com/browse/MGDAPI-3086)