### PR TITLE
MGDAPI-2981 - bump: operator-sdk 1.21.0

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,7 +1,7 @@
 FROM centos:7
 LABEL maintainer="mnairn@redhat.com"
 
-ENV OPERATOR_SDK_VERSION=v1.12.0 \
+ENV OPERATOR_SDK_VERSION=v1.21.0 \
     GOFLAGS="" \
     PATH=$PATH:/usr/local/go/bin
 


### PR DESCRIPTION
## Jira
https://issues.redhat.com/browse/MGDAPI-2981

## Description
Bump operator sdk version to match https://github.com/integr8ly/integreatly-operator/pull/2720

## Verification
* Verify image builds successfully
```
make image/build
```