### PR TITLE
fix null values for SMTP

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -281,19 +281,19 @@ install_addon() {
     fi
 
     # Add the custom SMTP parameters to addon payload if present in the command
-    if [[ -n "${SMTP_FROM}" ]]; then
+    if [[ -n "${SMTP_FROM}" && "${SMTP_FROM}" != "null" ]]; then
         addon_payload+=", {\"id\": \"custom-smtp-from_address\", \"value\": \"${SMTP_FROM}\"}"
     fi
-    if [[ -n "${SMTP_ADDRESS}" ]]; then
+    if [[ -n "${SMTP_ADDRESS}" && "${SMTP_FROM}" != "null" ]]; then
         addon_payload+=", {\"id\": \"custom-smtp-address\", \"value\": \"${SMTP_ADDRESS}\"}"
     fi
-    if [[ -n "${SMTP_USER}" ]]; then
+    if [[ -n "${SMTP_USER}" && "${SMTP_FROM}" != "null" ]]; then
         addon_payload+=", {\"id\": \"custom-smtp-username\", \"value\": \"${SMTP_USER}\"}"
     fi
-    if [[ -n "${SMTP_PASS}" ]]; then
+    if [[ -n "${SMTP_PASS}" && "${SMTP_FROM}" != "null" ]]; then
         addon_payload+=", {\"id\": \"custom-smtp-password\", \"value\": \"${SMTP_PASS}\"}"
     fi
-    if [[ -n "${SMTP_PORT}" ]]; then
+    if [[ -n "${SMTP_PORT}" && "${SMTP_FROM}" != "null" ]]; then
         addon_payload+=", {\"id\": \"custom-smtp-port\", \"value\": \"${SMTP_PORT}\"}"
     fi
 


### PR DESCRIPTION
## What
in pipelines, SMTP values are optional and could give us a `null` value. In theory `-n` should catch it, but it isn't always the case

## Verification

run 
```
make SMTP_FROM=null SMTP_ADDRESS=null SMTP_USER=null SMTP_PASS=null SMTP_PORT=null USE_CLUSTER_STORAGE=false WAIT=false QUOTA=200 ocm/install/rhoam-addon
```
and the no errors produced 