### PR TITLE
[MGDAPI-3624] Bumping go version to 1.18

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ vendor/check: vendor/fix
 
 .PHONY: vendor/fix
 vendor/fix:
-	go mod tidy -compat=1.17
+	go mod tidy -compat=1.18
 	go mod vendor

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -16,8 +16,8 @@ RUN set -o pipefail && \
     chmod +x /usr/local/bin/yq && \
     curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq && \
-    wget https://golang.org/dl/go1.17.6.linux-amd64.tar.gz && \
-    tar -zxvf go1.17.6.linux-amd64.tar.gz -C /usr/local/ && \
+    wget https://golang.org/dl/go1.18.linux-amd64.tar.gz && \
+    tar -zxvf go1.18.linux-amd64.tar.gz -C /usr/local/ && \
     curl -Ls https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.0.2/kustomize_v4.0.2_linux_amd64.tar.gz | tar -zx && \
     mv kustomize /usr/local/bin && \
     chmod +x /usr/local/bin/kustomize

--- a/cmd/getSupportedVersions_test.go
+++ b/cmd/getSupportedVersions_test.go
@@ -29,14 +29,6 @@ func TestGetSupportedVersionsCmd(t *testing.T) {
 			expectError:   false,
 		},
 		{
-			description:   "Run command for RHMI",
-			olmType:       "integreatly-operator",
-			majorVersions: 1,
-			minorVersions: 3,
-			repo:          "https://gitlab.cee.redhat.com/service/managed-tenants.git",
-			expectError:   false,
-		},
-		{
 			description:   "Run command with expected error",
 			olmType:       "managed-api-service",
 			majorVersions: 1,

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/integr8ly/delorean
 
-go 1.17
+go 1.18
 
 require (
 	github.com/aws/aws-sdk-go v1.35.24

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.17
+FROM registry.ci.openshift.org/openshift/release:golang-1.18
 
 ENV SHELLCHECK_VERSION=v0.7.0
 


### PR DESCRIPTION
### Issue Link
[MGDAPI-3624](https://issues.redhat.com/browse/MGDAPI-3624)

### Changes
- Updated go version in various files
- Removed redundant unit test case

### Verification Steps
> **Note** 
Vendor check will fail as delorean go version in openshift/release repo PR won't be created until after this PR is merged

- CLI build `make build/cli`
- Your IDE/local version of Go should be 1.18 > `go version` or check IDE in `settings > GOROOT` before running unit tests
- Unit test should pass `make test/unit`
- Container image builds `make image/build`
- For `openshift-ci/dockerfile.tools` builds run the build and test steps outlined in [openshift-ci/README](https://github.com/integr8ly/delorean/blob/master/openshift-ci/README.md)