### PR TITLE
addition of gcc and which commands to installation packages

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -8,7 +8,7 @@ ENV OPERATOR_SDK_VERSION=v1.21.0 \
 COPY resources/rhit-root-ca.crt /etc/pki/ca-trust/source/anchors/
 
 RUN set -o pipefail && \
-    INSTALL_PKGS="make rsync wget" && \
+    INSTALL_PKGS="make rsync wget gcc which" && \
     yum install -y --setopt=tsflags=nodocs $INSTALL_PKGS && \
     curl -Ls https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable/openshift-client-linux.tar.gz | tar -zx && \
     mv oc /usr/local/bin && \


### PR DESCRIPTION
[MGDAPI-4303](https://issues.redhat.com/browse/MGDAPI-4303)

# What 
CVE scan pipeline was failing due to `gcc` and `which` commands missing from Delorean images. Both commands are now installed using yum.

# Verification
1. Run pipeline in my [playground](https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/patryk/job/MGDAPI-4303/)
2. When building with parameters check dryRun and readinessReport.  
3. Verify pipeline builds successfully.

**Note:** pipeline is using custom delorean-cli image : quay.io/pstefans/delorean-cli:latest