### PR TITLE
MGDAPI-4390 Move rhsso to the productised Go operator - Delorean igno…

### DIFF
--- a/cmd/checkOLMGraph.go
+++ b/cmd/checkOLMGraph.go
@@ -10,6 +10,11 @@ import (
 	"path"
 )
 
+const (
+	baseKeycloakV18 = "keycloak-operator.v18.0.0"
+	baseKeycloakV9  = "keycloak-operator.v9.0.3"
+)
+
 type checkOLMGraphFlags struct {
 	directory string
 }
@@ -84,7 +89,7 @@ func checkGraphInDir(dirname string, csvs utils.CSVNames) error {
 	}
 	for i := csvs.Len() - 1; i > 0; i-- {
 		csv := csvs[i]
-		if !csvs.Contains(csv.Replaces) {
+		if !csvs.Contains(csv.Replaces) && (csv.Name != baseKeycloakV18) && (csv.Name != baseKeycloakV9) {
 			fmt.Println(fmt.Sprintf("[%s] OLM graph is broken. CSV %s replaces %s, which doesn't exist", dirname, csv.Name, csv.Replaces))
 			return errors.New(fmt.Sprintf("[%s] invalid replaces field %s in CSV %s", dirname, csv.Replaces, csv.Name))
 		}


### PR DESCRIPTION
# Issue link
MGDAPI-4390 Move rhsso to the productised Go operator 
Jira: https://issues.redhat.com/browse/MGDAPI-4390
## Delorean to ignore check of replaces values in base keycloak csv.

# What
This PR allow to avoid errors in PR `test manifest`, like *OLM graph is broken. CSV keycloak-operator.v18.0.0 replaces , which doesn't exist*.
We will ignore *base* versions, that doesn't contain `replace` field

# Verification steps
- Check that PR testing `test manifest` is pass successfully for PR 
  (https://github.com/integr8ly/integreatly-operator/pull/2850)
- Local test - check that no errors in `check-olm-graph` command, like below:
$ cd integreatly-operator
$ delorean  ews check-olm-graph -d ./manifests
