### PR TITLE
MGDAPI-4483 - Order bundles correctly by semver

### DIFF
--- a/cmd/update3scaleBundle.go
+++ b/cmd/update3scaleBundle.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 
 	"github.com/spf13/cobra"
+	"golang.org/x/mod/semver"
 	"gopkg.in/yaml.v3"
 )
 
@@ -111,7 +112,7 @@ func (cmd *Update3scaleBundleCommand) modifyBundles(bl *BundleList) error {
 	bl.Bundles = append(bl.Bundles, newBundle)
 
 	sort.Slice(bl.Bundles, func(i, j int) bool {
-		return bl.Bundles[i].Name < bl.Bundles[j].Name
+		return semver.Compare(bl.Bundles[i].Name, bl.Bundles[j].Name) == -1
 	})
 	return nil
 }


### PR DESCRIPTION
[MGDAPI-4483](https://issues.redhat.com/browse/MGDAPI-4483)

The bundle name string comparison resulted in the 3scale bundles being added to the list in the incorrect order - 0.10.0 < 0.9.0. Use `semver` instead to order the versions correctly.