### PR TITLE
MGDAPI-4920 Added multitenant support to create-release and merge-release commands

### DIFF
--- a/cmd/createRelease.go
+++ b/cmd/createRelease.go
@@ -182,7 +182,7 @@ func (c *createReleaseCmd) commitAndPushChanges(gitRepo *git.Repository, gitRepo
 	if err := gitRepoTree.AddGlob("."); err != nil {
 		return err
 	}
-	if _, err := gitRepoTree.Commit(fmt.Sprintf("MGDAPI-3209 prepare for release %s", c.version.TagName()), &git.CommitOptions{
+	if _, err := gitRepoTree.Commit(c.version.PrepareReleaseCommitMessage(), &git.CommitOptions{
 		All: true,
 		Author: &object.Signature{
 			Name:  commitAuthorName,
@@ -214,7 +214,7 @@ func (c *createReleaseCmd) createPRIfNotExists(ctx context.Context, releaseBranc
 	}
 	if pr == nil {
 		fmt.Println("Create PR for release")
-		t := fmt.Sprintf("release PR for version %s", c.version.TagName())
+		t := c.version.PrepareReleasePRTitle()
 		b := c.baseBranch.String()
 		req := &github.NewPullRequest{
 			Title: &t,

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,8 +1,9 @@
 package types
 
 const (
-	OlmTypeRhmi  = "integreatly-operator"
-	OlmTypeRhoam = "managed-api-service"
+	OlmTypeRhmi             = "integreatly-operator"
+	OlmTypeRhoam            = "managed-api-service"
+	OlmTypeMultitenantRhoam = "multitenant-managed-api-service"
 )
 
 type RhssoManifest struct {

--- a/pkg/utils/rhmi_version_test.go
+++ b/pkg/utils/rhmi_version_test.go
@@ -186,6 +186,12 @@ func TestNameByOlmType(t *testing.T) {
 			want:    "rhoam",
 		},
 		{
+			name:    "test that multitenant-managed-api-service returns rhoam",
+			olmType: "multitenant-managed-api-service",
+			version: "1.1.0",
+			want:    "rhoam",
+		},
+		{
 			name:    "test that integreatly-operaotr returns rhmi",
 			version: "2.7.0",
 			olmType: "integreatly-operator",


### PR DESCRIPTION
JIRA: [MGDAPI-4920](https://issues.redhat.com/browse/MGDAPI-4920)

This PR updates the `create-release` command to support `multitenant-managed-api-service` as an `olmType`.  When the `olmType` is set to `multitenant-managed-api-service`, delorean will create/merge the appropriate bundle files for multitenant RHOAM. This is required for the multitenant-rhoam-release Jenkins pipeline.