### PR TITLE
expose byovpc with private link option for ROSA clusters

### DIFF
--- a/scripts/rosa/rosa.sh
+++ b/scripts/rosa/rosa.sh
@@ -89,9 +89,11 @@ provision_rosa_cluster() {
     if [[ $BYOVPC = 'true' ]]; then
         if [[ -z $SUBNET_IDS || $SUBNET_IDS == '' ]]; then
           echo "a comma seperated list of subnet ids for your BYOVPC must provided"
+          exit 1
         fi
         args+=(--subnet-ids=$SUBNET_IDS)
         if [[ $PRIVATE_LINK = 'true' ]]; then
+          is_private_link_region
           args+=(--private-link)
         fi
         if [[ -n $MACHINE_CIDR && $MACHINE_CIDR != "" ]]; then
@@ -109,6 +111,28 @@ provision_rosa_cluster() {
     rosa create cluster "${args[@]}"
     rosa describe cluster --cluster $CLUSTER_NAME
     rosa logs install --cluster $CLUSTER_NAME --watch
+}
+
+is_private_link_region(){
+    # For private link enabled clusters at time of writing there is a limited set of regions where they can be installed.
+    # This rosa cli or ocm ui installation will fail silently if you are trying to install into one of those regions.
+    # See https://gitlab.cee.redhat.com/service/osd-aws-privatelink-terraform/-/blob/master/osd/variables.tf#L26-31 for regions enabled
+    # There is an epic to update the list https://issues.redhat.com/browse/SDE-2560 but it's not clear when this will be delivered
+    private_link_enabled_regions=("us-east-1" "us-east-2" "us-west-1" "us-west-2" "ap-northeast-3")
+    match=false
+    for i in "${private_link_enabled_regions[@]}"
+    do
+      if [[ "$i" == "$AWS_REGION" ]]; then
+        match=true
+        break
+      fi
+    done
+
+    if [[ "$match" == false ]]; then
+        echo "Private Link Clusters are not enabled in OCM staging environment for region $AWS_REGION"
+        echo "At time or writing the currently enabled regions are " "${private_link_enabled_regions[@]}"
+        exit 1
+    fi
 }
 
 delete_rosa_cluster() {


### PR DESCRIPTION
JIRA

https://issues.redhat.com/browse/MGDAPI-5065

WHAT
Exposes the options for deploying ROSA clusters to 
BYOVPC and Private Link Clusters.
If Multi AZ is true then there must be compute notes divisible by 3
and subnets must be provided.
In the case of BYOVPC the machine cidr must match the cidr value of the VPC so we need to allow that to be configured as well. 
If Private Link is used then the region being used much match a set that is allowable in staging environment for OCM. There is a JIRA linked about that and also some information linked in the JIRA for this ticket.
