### PR TITLE
MGDAPI-4922 - feat: copy addonImageSet for stable release

### DIFF
--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/integreatly-operator/addonimagesets/production/integreatly-operator.v1.0.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/integreatly-operator/addonimagesets/production/integreatly-operator.v1.0.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/integreatly-operator:v1.0.0
+name: integreatly-operator.v1.0.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/integreatly-operator/addonimagesets/stage/integreatly-operator.v1.0.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/integreatly-operator/addonimagesets/stage/integreatly-operator.v1.0.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/integreatly-operator:v1.0.0
+name: integreatly-operator.v1.0.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/managed-api-service-internal/addonimagesets/production/managed-api-service-internal.v1.0.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/managed-api-service-internal/addonimagesets/production/managed-api-service-internal.v1.0.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/managed-api-service-internal:v1.0.0
+name: managed-api-service-internal.v1.0.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/managed-api-service-internal/addonimagesets/stage/managed-api-service-internal.v1.0.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/managed-api-service-internal/addonimagesets/stage/managed-api-service-internal.v1.0.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/managed-api-service-internal:v1.0.0
+name: managed-api-service-internal.v1.0.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/production/rhoams.v1.27.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/production/rhoams.v1.27.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/rhoams-index@sha256:8b138902a4375420e003e5f8cbdda59ab41ab84f2e22111708de93d9629b601e
+name: rhoams.v1.27.5-1.27.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/rhoams-index@sha256:8b138902a4375420e003e5f8cbdda59ab41ab84f2e22111708de93d9629b601e
+name: rhoams.v1.27.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.1-1.26.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.1-1.26.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/rhoams-index@sha256:bd9f4c3153b94e49424b15edaee6868e39a00b65c4ba0cd80179f51687790efc
+name: rhoams.v1.27.1-1.26.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.2-1.27.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.2-1.27.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/rhoams-index@sha256:8b138902a4375420e003e5f8cbdda59ab41ab84f2e22111708de93d9629b601e
+name: rhoams.v1.27.2-1.27.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.3-1.27.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.3-1.27.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/rhoams-index@sha256:8b138902a4375420e003e5f8cbdda59ab41ab84f2e22111708de93d9629b601e
+name: rhoams.v1.27.3-1.27.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.4-1.26.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.4-1.26.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/rhoams-index@sha256:bd9f4c3153b94e49424b15edaee6868e39a00b65c4ba0cd80179f51687790efc
+name: rhoams.v1.27.4-1.26.0
+relatedImages: []

--- a/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.5-1.27.0.yaml
+++ b/cmd/testdata/osdAddonReleaseManagedTenants/addons/rhoams/addonimagesets/stage/rhoams.v1.27.5-1.27.0.yaml
@@ -1,0 +1,3 @@
+indexImage: quay.io/osd-addons/rhoams-index@sha256:8b138902a4375420e003e5f8cbdda59ab41ab84f2e22111708de93d9629b601e
+name: rhoams.v1.27.5-1.27.0
+relatedImages: []

--- a/go.mod
+++ b/go.mod
@@ -33,6 +33,7 @@ require (
 	k8s.io/cli-runtime v0.23.2
 	k8s.io/client-go v8.0.0+incompatible
 	k8s.io/utils v0.0.0-20211208161948-7d6a63dca704
+	sigs.k8s.io/kustomize/kyaml v0.13.0
 	sigs.k8s.io/yaml v1.2.0
 )
 
@@ -154,7 +155,6 @@ require (
 	k8s.io/kubectl v0.23.2 // indirect
 	rsc.io/letsencrypt v0.0.3 // indirect
 	sigs.k8s.io/kustomize/api v0.10.1 // indirect
-	sigs.k8s.io/kustomize/kyaml v0.13.0 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
 )
 


### PR DESCRIPTION
# Description
* Refactor to copy latest addon image set to stable channel production

Jira: https://issues.redhat.com/browse/MGDAPI-4922

# Verification
* Unit tests should cover it
* Passing prow checks
* Example MR - https://gitlab.cee.redhat.com/chfan/managed-tenants/-/merge_requests/5/diffs