### PR TITLE
Removed resource requirements parameter

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -333,7 +333,7 @@ install_addon() {
 
     # Add mandatory "cidr-range" and "addon-managed-api-service" (quota) params with default value in case of rhoam (managed-api-service) addon
     if [[ "${addon_id}" == "managed-api-service" ]]; then
-    	addon_payload="{\"addon\":{\"id\":\"${addon_id}\"}, \"parameters\": { \"items\": [{\"id\": \"cidr-range\", \"value\": \"10.1.0.0/26\"}, {\"id\": \"addon-resource-required\", \"value\": \"true\" }"
+    	addon_payload="{\"addon\":{\"id\":\"${addon_id}\"}, \"parameters\": { \"items\": [{\"id\": \"cidr-range\", \"value\": \"10.1.0.0/26\"}"
         if [[ "${osd_trial}" == "false" ]]; then
             addon_payload+=", {\"id\": \"addon-managed-api-service\", \"value\": \"${QUOTA}\"}"
         else


### PR DESCRIPTION
The required resource parameter has been removed from OCM stage:
https://gitlab.cee.redhat.com/service/managed-tenants/-/merge_requests/3804/diffs

We need to remove it from here too.

Verification steps

Eye review only. I tried locally and it worked - as you can see the addon installation has started:
```
CUSTOM_DOMAIN= SMTP_FROM= SMTP_ADDRESS= SMTP_USER= SMTP_PASS= SMTP_PORT= WAIT= QUOTA=1 USE_CLUSTER_STORAGE=false make ocm/install/rhoam-addon
Applying managed-api-service Add-on on a cluster with ID: 21odc8g1jrgon61acj4d0gs6pph15o6p
{
  "kind": "AddOnInstallation",
  "id": "managed-api-service",
  "href": "/api/clusters_mgmt/v1/clusters/21odc8g1jrgon61acj4d0gs6pph15o6p/addons/managed-api-service",
  "addon": {
    "kind": "AddOnLink",
    "href": "/api/clusters_mgmt/v1/addons/managed-api-service",
    "id": "managed-api-service"
  },
  "addon_version": {
    "kind": "AddOnVersion",
    "id": "1.31.0",
    "href": "/api/clusters_mgmt/v1/addons/managed-api-service/versions/1.31.0"
  },
  "state": "installing",
  "parameters": {
    "items": [
      {
        "id": "cidr-range",
        "value": "10.1.0.0/26"
      },
      {
        "id": "addon-managed-api-service",
        "value": "1"
      }
    ]
  },
  "billing": {
    "billing_model": "standard"
  },
  "creation_timestamp": "2023-02-08T08:11:40.26899046Z"
}
Waiting for rhmi installation CR to be created for 15m...
No resources found in redhat-rhoam-operator namespace.
Waiting for rhmi installation CR to be created... Trying again in 30s
No resources found in redhat-rhoam-operator namespace.
Waiting for rhmi installation CR to be created... Trying again in 30s
rhmi installation CR to be created finished!
Patching RHMI CR
rhmi.integreatly.org/rhoam patched
Waiting for rhmi installation for 90m...
Waiting for rhmi installation... Trying again in 300s
```