### PR TITLE
Using mode flag for STS only

### DIFF
--- a/scripts/rosa/rosa.sh
+++ b/scripts/rosa/rosa.sh
@@ -101,13 +101,13 @@ provision_rosa_cluster() {
         fi
     fi
     if [[ $STS_ENABLED == 'true' ]]; then
-        args+=(--sts)
+        args+=(--sts --mode auto)
         rosa create account-roles --mode auto -y
         sleep 30
     else
         args+=(--non-sts)
     fi
-    args+=(-y --mode auto)
+    args+=(-y)
     rosa create cluster "${args[@]}"
     rosa describe cluster --cluster $CLUSTER_NAME
     rosa logs install --cluster $CLUSTER_NAME --watch


### PR DESCRIPTION
The `--mode` flag is only applicable for ROSA STS.

Verification steps

Eye review. See the excerpts from terminal when testing this:

```
$ make ocm/rosa/cluster/create STS_ENABLED=false AWS_REGION=us-east-1 CLUSTER_NAME=trepel USE_LOCAL_CREDENTIALS=true
...
+ args=(--cluster-name $CLUSTER_NAME --region $AWS_REGION --compute-machine-type $MACHINE_TYPE)
+ [[ false == \t\r\u\e ]]
+ args+=(--replicas $COMPUTE_NODES)
+ [[ false == \t\r\u\e ]]
+ [[ false = \t\r\u\e ]]
+ [[ false == \t\r\u\e ]]
+ args+=(--non-sts)
+ args+=(-y)
+ rosa create cluster --cluster-name trepel --region us-east-1 --compute-machine-type m5.xlarge --replicas 4 --non-sts -y
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
I: Creating cluster 'trepel'
...
```

```
$ make ocm/rosa/cluster/create STS_ENABLED=true AWS_REGION=us-east-1 COMPUTE_NODES=4 CLUSTER_NAME=trepel
...
+ args=(--cluster-name $CLUSTER_NAME --region $AWS_REGION --compute-machine-type $MACHINE_TYPE)
+ [[ false == \t\r\u\e ]]
+ args+=(--replicas $COMPUTE_NODES)
+ [[ false == \t\r\u\e ]]
+ [[ false = \t\r\u\e ]]
+ [[ true == \t\r\u\e ]]
+ args+=(--sts --mode auto)
...
+ args+=(-y)
+ rosa create cluster --cluster-name trepel --region us-east-1 --compute-machine-type m5.xlarge --replicas 4 --sts --mode auto -y
W: In a future release STS will be the default mode.
W: --sts flag won't be necessary if you wish to use STS.
W: --non-sts/--mint-mode flag will be necessary if you do not wish to use STS.
I: Using arn:aws:iam::342316834583:role/ManagedOpenShift-Installer-Role for the Installer role
I: Using arn:aws:iam::342316834583:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
I: Using arn:aws:iam::342316834583:role/ManagedOpenShift-Worker-Role for the Worker role
I: Using arn:aws:iam::342316834583:role/ManagedOpenShift-Support-Role for the Support role
I: Creating cluster 'trepel'
...
```

Note that there is no warning
```
00:15:28  + args+=(--non-sts)
00:15:28  + args+=(-y --mode auto)
00:15:28  + rosa create cluster --cluster-name rosa-combined2 --region us-east-2 --compute-machine-type m5.xlarge --replicas 4 --non-sts -y --mode auto
00:15:29  WARN: --mode is only valid for STS clusters
00:15:29  WARN: --mode is only valid for STS clusters
```
You can see this warning e.g. here:
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/ckyrillo/job/Manual/job/managed-api-rosa-combined/2/consoleFull
