### PR TITLE
Custom domain support

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -343,6 +343,11 @@ install_addon() {
         fi
     fi
 
+    # Add custom domain to addon payload if specified
+    if [[ -n "${CUSTOM_DOMAIN}" ]]; then
+        addon_payload+=", {\"id\": \"custom-domain_domain\", \"value\": \"${CUSTOM_DOMAIN}\"}"
+    fi
+
     # Add the custom SMTP parameters to addon payload if present in the command
     if [[ -n "${SMTP_FROM}" ]]; then
         addon_payload+=", {\"id\": \"custom-smtp-from_address\", \"value\": \"${SMTP_FROM}\"}"


### PR DESCRIPTION
Allow for specifying custom domain addon parameter via CUSTOM_DOMAIN env var.

Verification Steps

Validated via
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/Playground/job/trepel/job/rhoam-addon-flow-custd/3/console

As you can see in the build log the param was passed to the OCM and addon is being installed with the proper value.