### PR TITLE
MGDAPI-5498 fix: getSupportedVersions

### DIFF
--- a/cmd/getSupportedVersions_test.go
+++ b/cmd/getSupportedVersions_test.go
@@ -2,13 +2,14 @@ package cmd
 
 import (
 	"context"
-	"github.com/blang/semver"
-	"github.com/integr8ly/delorean/pkg/types"
 	"os"
 	"path"
 	"reflect"
 	"strings"
 	"testing"
+
+	"github.com/blang/semver"
+	"github.com/integr8ly/delorean/pkg/types"
 )
 
 func TestGetSupportedVersionsCmd(t *testing.T) {
@@ -343,25 +344,25 @@ func compareMinorVersionResult(versions map[int][]int, expected map[int][]int) b
 
 func TestGetOlmTypePath(t *testing.T) {
 	cases := []struct {
-		description        string
-		olmType            string
-		expectedBundlePath string
-		expectedFilePath   string
-		expectedError      string
-		hasError           bool
+		description          string
+		olmType              string
+		expectedBundlePath   string
+		expectedImageSetPath string
+		expectedError        string
+		hasError             bool
 	}{
 		{
-			description:        "Get values for RHOAM",
-			olmType:            types.OlmTypeRhoam,
-			expectedBundlePath: "managed-api-service",
-			expectedFilePath:   "addons/rhoams/metadata/production/addon.yaml",
-			hasError:           false,
+			description:          "Get values for RHOAM",
+			olmType:              types.OlmTypeRhoam,
+			expectedBundlePath:   "managed-api-service",
+			expectedImageSetPath: "addons/rhoams/addonimagesets/production",
+			hasError:             false,
 		},
 		{
-			description:        "Get values for RHMI",
-			olmType:            types.OlmTypeRhmi,
-			expectedBundlePath: "addons/integreatly-operator/bundles",
-			expectedFilePath:   "addons/integreatly-operator/metadata/production/addon.yaml",
+			description:          "Get values for RHMI",
+			olmType:              types.OlmTypeRhmi,
+			expectedBundlePath:   "integreatly-operator",
+			expectedImageSetPath: "addons/integreatly-operator/addonimagesets/production",
 
 			hasError: false,
 		},
@@ -387,8 +388,8 @@ func TestGetOlmTypePath(t *testing.T) {
 					t.Fatalf("Wrong path returned. Expected: %s, Recived: %s", c.expectedBundlePath, paths.bundleFolder)
 				}
 
-				if paths.addonFilePath != c.expectedFilePath && !c.hasError {
-					t.Fatalf("Wrong path returned. Expected: %s, Recived: %s", c.expectedFilePath, paths.addonFilePath)
+				if paths.addonImageSetDirPath != c.expectedImageSetPath && !c.hasError {
+					t.Fatalf("Wrong path returned. Expected: %s, Recived: %s", c.expectedImageSetPath, paths.addonImageSetDirPath)
 				}
 			}
 		})
@@ -442,7 +443,7 @@ func TestGetProductionVersion(t *testing.T) {
 			description: "Get production version for rhoam",
 			repoDir:     path.Join(basedir, "testdata/getSupportedVersions/managed-tenants"),
 			paths: olmPaths{
-				addonFilePath: "addons/rhoams/metadata/production/addon.yaml",
+				packageFilePath: "addons/rhoams/metadata/production/addon.yaml",
 			},
 			expected: semver.Version{Major: 1, Minor: 6, Patch: 1},
 		},
@@ -450,7 +451,7 @@ func TestGetProductionVersion(t *testing.T) {
 			description: "Get production version for rhmi",
 			repoDir:     path.Join(basedir, "testdata/getSupportedVersions/managed-tenants"),
 			paths: olmPaths{
-				addonFilePath: "addons/integreatly-operator/metadata/production/addon.yaml",
+				packageFilePath: "addons/integreatly-operator/metadata/production/addon.yaml",
 			},
 			expected: semver.Version{Major: 2, Minor: 8, Patch: 0},
 		},

--- a/cmd/osdAddonRelease.go
+++ b/cmd/osdAddonRelease.go
@@ -520,19 +520,11 @@ func (c *osdAddonReleaseCmd) copyTheOLMBundles() (string, error) {
 	return relativeDestination, nil
 }
 
+// getLatestStageAddonImageSetPath returns the file name of the last file in the staging addon directory sorted by name
 func (c *osdAddonReleaseCmd) getLatestStageAddonImageSetPath() (string, error) {
 	filePath := path.Join(c.managedTenantsDir, c.currentChannel.stageAddonImageSetDirectory())
-	files, err := ioutil.ReadDir(filePath)
-	if err != nil {
-		return "", err
-	}
 
-	if len(files) == 0 {
-		return "", fmt.Errorf("no files found in stage addon image set directory")
-	}
-
-	// Latest addonImageSet should be the last one
-	return path.Join(filePath, files[len(files)-1].Name()), nil
+	return getLastFileInDir(filePath)
 }
 func (c *osdAddonReleaseCmd) getAddonImageSetName() string {
 	return fmt.Sprintf("%s.v%s", c.currentChannel.Directory, c.version.String())


### PR DESCRIPTION
# Description
`getSupportedVersions` cmd was broken due to the shift to use addonImageSets as the addon.yaml no longer contains an `indexImage` field. This causes the field to be an empty string and subsequently causes opm to fail to extract the bundles from this empty field 

# Verification
* Passing unit tests in prow checks should be sufficient
