### PR TITLE
Updated timeouts related to cluster creation

### DIFF
--- a/scripts/ocm/ocm.sh
+++ b/scripts/ocm/ocm.sh
@@ -289,8 +289,8 @@ create_cluster() {
         exit 1
     fi
 
-    : "${TIMEOUT_CLUSTER_CREATION:=180}"
-    : "${TIMEOUT_CLUSTER_HEALTH_CHECK:=30}"
+    : "${TIMEOUT_CLUSTER_CREATION:=120}"
+    : "${TIMEOUT_CLUSTER_HEALTH_CHECK:=15}"
 
     echo "Sending a request to OCM to create an OSD cluster"
     send_cluster_create_request


### PR DESCRIPTION
Updated timeouts related to cluster creation
- 120m for cluster creation. Typical time is 40-70 minutes so 180m is overkili
- 15m for getting healthy. Typically this is either below 10 minutes or it never happens