### PR TITLE
MGDAPI-3584 - fix: use quay busybox image to prevent docker rate limit

### DIFF
--- a/cmd/productTests.go
+++ b/cmd/productTests.go
@@ -294,7 +294,7 @@ func getTestContainerJob(namespace string, t *TestContainer) *batchv1.Job {
 						},
 						{
 							Name:  "sidecar",
-							Image: "busybox",
+							Image: "quay.io/quay/busybox:latest",
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "test-run-results",


### PR DESCRIPTION
* Occasionally there might be an error pulling the busybox image from docker.io due to being rate limited preventing test suite from completing successfully

```
  containerStatuses:
    - name: sidecar
      state:
        waiting:
          reason: ErrImagePull
          message: >-
            rpc error: code = Unknown desc = reading manifest latest in
            docker.io/library/busybox: toomanyrequests: You have reached your
            pull rate limit. You may increase the limit by authenticating and
            upgrading: https://www.docker.com/increase-rate-limit
      lastState: {}
      ready: false
      restartCount: 0
      image: busybox
      imageID: ''
      started: false
```