### PR TITLE
Added Internet Gateway permission for STS Jenkins role

### DIFF
--- a/scripts/rosa/rosa.sh
+++ b/scripts/rosa/rosa.sh
@@ -208,6 +208,7 @@ EOM
                 "ec2:DescribeSubnets",
                 "ec2:DescribeVpcPeeringConnections",
                 "ec2:DescribeVpcs",
+                "ec2:DescribeInternetGateways",
                 "elasticache:DescribeCacheClusters",
                 "elasticache:DescribeReplicationGroups",
                 "elasticache:DescribeCacheSubnetGroups",


### PR DESCRIPTION
Internet Gateway permission is required for functional tests now because this has been merged: https://github.com/integr8ly/integreatly-operator/pull/3239

### Verification

Eye review. It is quite tricky to validate on cluster so I think that this is optional for this simple change but here are the steps:
- have a ROSA STS cluster
- checkout this PR
- `make ocm/sts/sts-cluster-prerequisites CLUSTER_NAME=yourRosaStsClusterName ROLE_NAME=rhoam_role_jenkins FUNCTIONAL_TEST_ROLE_NAME=functional_test_role_jenkins`

Then you either run the test via /single target (from integreatly-operator repo):
`LOCAL=false INSTALLATION_TYPE=managed-api TOKEN_PATH=/var/run/secrets/openshift/serviceaccount/token ROLE_ARN=arn:aws:iam::yourAwsAccountId:role/functional_test_role_jenkins TEST=A25 make test/e2e/single`
but you need to be logged in AWS as osdCcsAdmin so you need to use your personal IAM user to generate an Access Key for osdCcsAdmin first

Or use delorean to run the test in cluster. Be sure to be logged in as kubeadmin:
`delorean pipeline product-tests --test-config test-config.yaml --output test-results --namespace test-functional --post-cleanup false`

The test-config.yaml example:
```
$ cat test-config.yaml 
---

tests:
- name: integreatly-operator-test
  image: quay.io/integreatly/integreatly-operator-test-harness:master
  timeout: 7200
  regExpFilter: "A25"
  envVars:
  - name: DESTRUCTIVE
    value: 'false'
  - name: MULTIAZ
    value: 'false'
  - name: WATCH_NAMESPACE
    value: redhat-rhoam-operator
  - name: BYPASS_STORAGE_TYPE_CHECK
    value: 'true'
  - name: ROLE_ARN
    value: arn:aws:iam::yourAwsAccountId:role/functional_test_role_jenkins
  - name: TOKEN_PATH
    value: /var/run/secrets/openshift/serviceaccount/token
  - name: LOCAL
    value: 'false'
  - name: INSTALLATION_TYPE
    value: managed-api
```
