### PR TITLE
MGDAPI-5854 - go: v1.19

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ vendor/check: vendor/fix
 
 .PHONY: vendor/fix
 vendor/fix:
-	go mod tidy -compat=1.18
+	go mod tidy -compat=1.19
 	go mod vendor

--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -18,8 +18,8 @@ RUN set -o pipefail && \
     chmod +x /usr/local/bin/yq && \
     curl -Lo /usr/local/bin/jq https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64 && \
     chmod +x /usr/local/bin/jq && \
-    wget https://golang.org/dl/go1.18.linux-amd64.tar.gz && \
-    tar -zxvf go1.18.linux-amd64.tar.gz -C /usr/local/ && \
+    wget https://golang.org/dl/go1.19.linux-amd64.tar.gz && \
+    tar -zxvf go1.19.linux-amd64.tar.gz -C /usr/local/ && \
     curl -Ls https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v4.0.2/kustomize_v4.0.2_linux_amd64.tar.gz | tar -zx && \
     mv kustomize /usr/local/bin && \
     chmod +x /usr/local/bin/kustomize

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/integr8ly/delorean
 
-go 1.18
+go 1.19
 
 require (
 	github.com/aws/aws-sdk-go v1.35.24

--- a/openshift-ci/Dockerfile.tools
+++ b/openshift-ci/Dockerfile.tools
@@ -1,4 +1,4 @@
-FROM registry.ci.openshift.org/openshift/release:golang-1.18
+FROM registry.ci.openshift.org/openshift/release:golang-1.19
 
 ENV SHELLCHECK_VERSION=v0.7.0
 


### PR DESCRIPTION
* Update to use go 1.19
  *  `vendor` prow test will fail until this PR gets merged and the prow configuration is auto updated to use the new go version