### PR TITLE
Add rhssouser to options for types file

### DIFF
--- a/cmd/manageRHMITypes.go
+++ b/cmd/manageRHMITypes.go
@@ -106,6 +106,8 @@ func PrepareProductName(product string) string {
 		product = "FuseOnline"
 	case "rhsso":
 		product = "RHSSO"
+	case "rhssouser":
+		product = "RHSSOUser"
 	}
 
 	return product


### PR DESCRIPTION
I spotted that it's not possible to use the delorean command to update the `rhssouser` in types file but you can set `rhsso`. Added it as an option.

You can check the functionality with the following:

```
delorean ews set-product-operator-version -f apis/v1alpha1/rhmi_types.go -p rhssouser -v 7.6.4 -e 7.6.1
```

And verify it does not affect the RHSSO command:

```
delorean ews set-product-operator-version -f apis/v1alpha1/rhmi_types.go -p rhsso -v 7.6.5 -e 7.6.2
```