### PR TITLE
MGDAPI-6003 fix polarion import pipeline

### DIFF
--- a/cmd/polarionImport.go
+++ b/cmd/polarionImport.go
@@ -209,7 +209,7 @@ func (c *polarionImportCmd) processReportFile(ctx context.Context, object *s3.Ob
 func (c *polarionImportCmd) importToPolarion(key string, metadata *testMetadata, zipfile string) error {
 
 	// Do not import master/nightly tests
-	if metadata.RHMIVersion == "" {
+	if metadata.RHMIVersion == "" || metadata.RHMIVersion == "null" {
 		fmt.Printf("[%s] ignore test results %s %s\n", key, metadata.Name, metadata.RHMIVersion)
 		return nil
 	}

--- a/configurations/cleanup-reports.yaml
+++ b/configurations/cleanup-reports.yaml
@@ -1,15 +1,5 @@
 ---
 configs:
-  - bucket: rhmi-test-data-storage-tf56
-    tags:
-      - key: polarion
-        value: true
-      - key: rp
-        value: true
-  - bucket: rhmi-test-data-storage-tf56
-    tags:
-      - key: datahub
-        value: true
   - bucket: rhoam-test-data-storage-4mk5
     tags:
       - key: polarion


### PR DESCRIPTION
In the `rhoam-import-testing-results` we had a problem with one log being uploaded with  the version tag of "null", crashing the whole pipeline on upload due to the code trying to parse the string as a version number. Running the pipeline with this fix fixed that and that section works now, this is a precaution in case it happens again.

the fix to cleanup-reports.yaml got the last stage of the pipeline working locally, as it's not trying to clean up the RHMI s3 buckets that don't exist anymore.


Verification steps:
enable Nightly pipelines in `local.sh`

start jenkins locally with `delorean-cli` container pointing to `image: "quay.io/mhesko0/delorean-cli:latest"`


Run the `rhoam-import-testing-results` pipeline, it should pass.