### PR TITLE
Allow for specifying OSD version for ROSA

### DIFF
--- a/scripts/rosa/rosa.sh
+++ b/scripts/rosa/rosa.sh
@@ -69,7 +69,7 @@ PRIVATE_LINK="${PRIVATE_LINK:-false}"
 BYOVPC="${BYOVPC:-false}"
 SUBNET_IDS="${SUBNET_IDS-""}"
 MACHINE_CIDR="${MACHINE_CIDR-""}"
-
+OSD_VERSION="${OSD_VERSION-""}"
 
 provision_rosa_cluster() {
     rosa login --env=$OCM_ENV
@@ -99,6 +99,9 @@ provision_rosa_cluster() {
         if [[ -n $MACHINE_CIDR && $MACHINE_CIDR != "" ]]; then
           args+=(--machine-cidr=$MACHINE_CIDR)
         fi
+    fi
+    if [[ -n $OSD_VERSION && OSD_VERSION != "" ]]; then
+        args+=(--version $OSD_VERSION)
     fi
     if [[ $STS_ENABLED == 'true' ]]; then
         args+=(--sts --mode auto)


### PR DESCRIPTION
Allow for specifying OpenShift version for ROSA.

## Verification Steps

1) make ocm/rosa/cluster/create OSD_VERSION=4.13.25

It is enough to wait and see that `--version 4.13.25` is used when executing `rosa create cluster` command. No need to wait for the cluster to come up.

2) make ocm/rosa/cluster/create

It is enough to see that `--version` switch is not used for `rosa create cluster` command. No need to wait for the cluster to come up.