### PR TITLE
Moved to ubi9 in Dockerfile

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi:latest
+FROM registry.access.redhat.com/ubi9/ubi:latest
 LABEL maintainer="mnairn@redhat.com"
 
 ENV OPERATOR_SDK_VERSION=v1.21.0 \


### PR DESCRIPTION
## Overview

Moved to ubi9 in Dockerfile. Main driver was that `opm` does not work on ubi8 due to requiring newer GLIBC version.

## Verification Steps

* `CONTAINER_ENGINE=podman DELOREAN_IMAGE=quay.io/<quay-org>/delorean-cli:latest make image/build`
* `CONTAINER_ENGINE=podman DELOREAN_IMAGE=quay.io/<quay-org>/delorean-cli:latest make image/test`
* `podman run --rm -it --entrypoint=/bin/bash quay.io/<quay-org>/delorean-cli:latest`

Then execute
`delorean -m=1 pipeline supported-versions` (it uses opm under the hood)

However, I validated this via pipeline:
https://master-jenkins-csb-intly.apps.ocp-c1.prod.psi.redhat.com/job/ManagedAPI/job/cve-scan/110/console
- it uses `quay.io/trepel/delorean-cli:latest` image I built out of this PR