### PR TITLE
Removal of redundant ROSA login

### DIFF
--- a/scripts/rosa/rosa.sh
+++ b/scripts/rosa/rosa.sh
@@ -72,7 +72,8 @@ MACHINE_CIDR="${MACHINE_CIDR-""}"
 OSD_VERSION="${OSD_VERSION-""}"
 
 provision_rosa_cluster() {
-    rosa login --env=$OCM_ENV
+    # This seems to make login session expire after 15 minutes
+    # rosa login --env=$OCM_ENV
     args=(--cluster-name $CLUSTER_NAME --region $AWS_REGION --compute-machine-type $MACHINE_TYPE)
     if [[ $ENABLE_AUTOSCALING == 'true' ]]; then
         args+=(--enable-autoscaling --min-replicas $MIN_REPLICAS --max-replicas $MAX_REPLICAS)


### PR DESCRIPTION
## Overview

This command used to do nothing, just printed login info. However, after changing login from user's OCM Token to service account's client ID/client secret it seems that this call also make login session expire after 15 minutes.

## Verification Steps
Download latest rosa cli:
- wget https://github.com/openshift/rosa/releases/latest/download/rosa_Linux_x86_64.tar.gz
- unzip it

Create a cluster
- ./rosa login --client-id=*** --client-secret=**** --env=staging
- CLUSTER_NAME=test MULTI_AZ=false AWS_REGION=us-east-1 MACHINE_TYPE=m5.xlarge COMPUTE_NODES=3 ENABLE_AUTOSCALING=false STS_ENABLED=true BYOVPC=false PRIVATE_LINK=false make ocm/rosa/cluster/create

Watch installation logs
- ./rosa logs install --cluster test --watch

It took longer than 15 minutes to provision a cluster so if the login session expires the '--watch' command fails. If all good then the command should finish successfully once the cluster is provisioned