### PR TITLE
Moving away from Docker Hub

### DIFF
--- a/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0-rc1/bundles/integreatly-operator/1.1.0/bundle.Dockerfile
+++ b/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0-rc1/bundles/integreatly-operator/1.1.0/bundle.Dockerfile
@@ -1,1 +1,1 @@
-FROM centos:7
+FROM mirror.gcr.io/library/centos:7

--- a/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0-rc1/bundles/managed-api-service/1.1.0/bundle.Dockerfile
+++ b/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0-rc1/bundles/managed-api-service/1.1.0/bundle.Dockerfile
@@ -1,1 +1,1 @@
-FROM centos:7
+FROM mirror.gcr.io/library/centos:7

--- a/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0/bundles/integreatly-operator/1.1.0/bundle.Dockerfile
+++ b/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0/bundles/integreatly-operator/1.1.0/bundle.Dockerfile
@@ -1,1 +1,1 @@
-FROM centos:7
+FROM mirror.gcr.io/library/centos:7

--- a/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0/bundles/managed-api-service/1.1.0/bundle.Dockerfile
+++ b/cmd/testdata/osdAddonReleaseIntegreatlyOperator1.1.0/bundles/managed-api-service/1.1.0/bundle.Dockerfile
@@ -1,1 +1,1 @@
-FROM centos:7
+FROM mirror.gcr.io/library/centos:7


### PR DESCRIPTION
Images are identical, so `podman pull mirror.gcr.io/library/centos:7` should be enough for validation. To be honest not sure if these files are still in use.